### PR TITLE
Additional fixes in Type.php

### DIFF
--- a/lib/Horde/Form/Type.php
+++ b/lib/Horde/Form/Type.php
@@ -564,6 +564,7 @@ class Horde_Form_Type_ipaddress extends Horde_Form_Type_text
 
             if (!$valid) {
                 $message = Horde_Form_Translation::t("Please enter a valid IP address.");
+                $this->message = $message;
             }
         } elseif ($var->isRequired()) {
             $valid = false;
@@ -715,14 +716,14 @@ class Horde_Form_Type_countedtext extends Horde_Form_Type_longtext
         if ($var->isRequired() && $length <= 0) {
             $valid = false;
             $message = Horde_Form_Translation::t("This field is required.");
-
+            $this->message = $message;
         } elseif ($length > $this->_chars) {
             $valid = false;
             $message = sprintf(Horde_Form_Translation::ngettext("There are too many characters in this field. You have entered %d character; ", "There are too many characters in this field. You have entered %d characters; ", $length), $length)
                 . sprintf(Horde_Form_Translation::t("you must enter less than %d."), $this->_chars);
+            $this->message = $message;
         }
 
-        $this->message = (string)$message;
         return $valid;
     }
 
@@ -1180,7 +1181,7 @@ class Horde_Form_Type_image extends Horde_Form_Type
             } elseif (!empty($field['hash'])) {
                 if ($this->_img && isset($this->_img['error'])) {
                     $message = $this->_img['error'];
-            $this->message = $message;
+                    $this->message = $message;
                     return false;
                 }
                 /* Nothing uploaded but older upload present. */
@@ -1188,6 +1189,7 @@ class Horde_Form_Type_image extends Horde_Form_Type
             } else {
                 /* Some other error message. */
                 $message = $this->_uploaded->getMessage();
+                $this->message = $message;
                 return false;
             }
         } elseif (empty($this->_img['img']['size'])) {
@@ -1656,7 +1658,7 @@ class Horde_Form_Type_email extends Horde_Form_Type
             } else {
                 $message = Horde_Form_Translation::t("You must enter an email address.");
             }
-            $this->message = (string)$message;
+            $this->message = $message;
             return false;
         }
 
@@ -4181,8 +4183,6 @@ class Horde_Form_Type_category extends Horde_Form_Type
 
 class Horde_Form_Type_invalid extends Horde_Form_Type
 {
-    public string $message;
-
     /**
      * Initialize an Invalid Message form type
      *

--- a/lib/Horde/Form/Type.php
+++ b/lib/Horde/Form/Type.php
@@ -1178,7 +1178,8 @@ class Horde_Form_Type_image extends Horde_Form_Type
                 $message = Horde_Form_Translation::t("This field is required.");
                 $this->message = $message;
                 return false;
-            } elseif (!empty($field['hash'])) {
+            }
+            if (!empty($field['hash'])) {
                 if ($this->_img && isset($this->_img['error'])) {
                     $message = $this->_img['error'];
                     $this->message = $message;
@@ -1186,17 +1187,18 @@ class Horde_Form_Type_image extends Horde_Form_Type
                 }
                 /* Nothing uploaded but older upload present. */
                 return true;
-            } else {
-                /* Some other error message. */
-                $message = $this->_uploaded->getMessage();
-                $this->message = $message;
-                return false;
             }
-        } elseif (empty($this->_img['img']['size'])) {
+            /* Some other error message. */
+            $message = $this->_uploaded->getMessage();
+            $this->message = $message;
+            return false;
+        }
+        if (empty($this->_img['img']['size'])) {
             $message = Horde_Form_Translation::t("The image file size could not be determined or it was 0 bytes. The upload may have been interrupted.");
             $this->message = $message;
             return false;
-        } elseif ($this->_max_filesize &&
+        }
+        if ($this->_max_filesize &&
                   $this->_img['img']['size'] > $this->_max_filesize) {
             $message = sprintf(Horde_Form_Translation::t("The image file was larger than the maximum allowed size (%d bytes)."), $this->_max_filesize);
             $this->message = $message;
@@ -1217,14 +1219,15 @@ class Horde_Form_Type_image extends Horde_Form_Type
         /* Check if we have image data */
         if (!isset($this->_img) || !isset($this->_img['img'])) {
             $info = '';
-            return;
+            return $info;
         }
 
         $info = $this->_img['img'];
         if (empty($info['file'])) {
             unset($info['file']);
-            return;
+            return $info;
         }
+
         if ($this->_show_keeporig) {
             $info['keep_orig'] = !empty($value['keep_orig']);
         }
@@ -3407,8 +3410,7 @@ class Horde_Form_Type_datetime extends Horde_Form_Type
          * default. */
         $value = $var->getValue($vars);
         if ($this->emptyDateArray($value) == 1 || $this->emptyTimeArray($value)) {
-            $this->_getInfo($var->getDefault(), $info);
-            return;
+            return $this->_getInfo($var->getDefault(), $info);
         }
 
         return $this->_getInfo($value, $info);
@@ -3418,8 +3420,7 @@ class Horde_Form_Type_datetime extends Horde_Form_Type
     {
         // If any component is empty consider it a bad date and return null
         if ($this->emptyDateArray($value) != 0 || $this->emptyTimeArray($value)) {
-            $info = null;
-            return;
+            return null;
         }
 
         $date = $this->getDateOb($value);


### PR DESCRIPTION
I could not commit directly (no access for some reason).

There are many more places that depend on `Horde_Form_Type` which have to be modified. Only to be modified yet again for V3.

But to actually make use of the returned error messages all dependents have to start using`getMessage()`.

To simplify the code I propose to add (and use) a method like this to `Horde_Form_Type` class:

```php
public function returnError($message) {
    $this->message = $message;
    return false;
}
```
Any objections?
