### PR TITLE
getType(): flatten named parameters before calling init()

### DIFF
--- a/lib/Horde/Form.php
+++ b/lib/Horde/Form.php
@@ -32,6 +32,8 @@ if (!class_exists('Horde_Form_Type'))
  */
 class Horde_Form
 {
+    protected static $init_params_cache = [];
+
     protected $_name = '';
     protected $_title = '';
     protected $_extra = '';
@@ -163,7 +165,7 @@ class Horde_Form
      *
      * @throws Horde_Exception
      */
-    public function getType($type, $params = [])
+    private function getType($type, $params = [])
     {
         if (strpos($type, ':') !== false) {
             [$app, $type] = explode(':', $type);
@@ -178,7 +180,25 @@ class Horde_Form
         if (!$params) {
             $params = [];
         }
-        call_user_func_array([$type_ob, 'init'], $params);
+
+        // retrieve list of parameters
+        $keys = self::$init_params_cache[$type_class] ?? null;
+        if (is_null($keys)) {
+            $keys = array_keys($type_ob->about()['params'] ?? []);
+            self::$init_params_cache[$type_class] = $keys;
+        }
+
+        // convert named keys to numeric indexes
+        $i = 0;
+        foreach ($keys as $key) {
+            if (array_key_exists($key, $params)) {
+                $params[$i] = $params[$key];
+                unset($params[$key]);
+            }
+            ++$i;
+        }
+
+        $type_ob->init(...$params);
         return $type_ob;
     }
 

--- a/lib/Horde/Form/Type.php
+++ b/lib/Horde/Form/Type.php
@@ -91,6 +91,11 @@ class Horde_Form_Type
         return false;
     }
 
+    public function about()
+    {
+        return ['name' => $this->getTypeName()];
+    }
+
 }
 
 class Horde_Form_Type_spacer extends Horde_Form_Type
@@ -244,7 +249,11 @@ class Horde_Form_Type_number extends Horde_Form_Type
      */
     public function about()
     {
-        return ['name' => Horde_Form_Translation::t("Number")];
+        return [
+            'name' => Horde_Form_Translation::t("Number"),
+            'params' => [
+                'fraction'  => ['label' => Horde_Form_Translation::t("Fraction"),
+                    'type'  => 'int']]];
     }
 
 }
@@ -1480,7 +1489,10 @@ class Horde_Form_Type_link extends Horde_Form_Type
         return [
             'name' => Horde_Form_Translation::t("Link"),
             'params' => [
-                'url' => [
+                'values' => [
+                    'label' => Horde_Form_Translation::t("Values"),
+                    'type' => 'array']
+/*                'url' => [
                     'label' => Horde_Form_Translation::t("Link URL"),
                     'type' => 'text'],
                 'text' => [
@@ -1501,7 +1513,8 @@ class Horde_Form_Type_link extends Horde_Form_Type
                 'class' => [
                     'label' => Horde_Form_Translation::t("Link CSS class"),
                     'type' => 'text'],
-            ],
+*/
+            ]
         ];
     }
 
@@ -2270,8 +2283,7 @@ class Horde_Form_Type_matrix extends Horde_Form_Type
             unset($values['n']);
         }
 
-        $info = ($values['r'] ?? []);
-        return $info;
+        return $values['r'] ?? [];
     }
 
     public function about()
@@ -2279,8 +2291,24 @@ class Horde_Form_Type_matrix extends Horde_Form_Type
         return [
             'name' => Horde_Form_Translation::t("Field matrix"),
             'params' => [
-                'cols' => ['label' => Horde_Form_Translation::t("Column titles"),
-                    'type'  => 'stringarray']]];
+                'cols' => [
+                    'label' => Horde_Form_Translation::t("Column titles"),
+                    'type'  => 'stringarray'
+                ],
+                'rows' => [
+                    'label' => Horde_Form_Translation::t("Row titles"),
+                    'type'  => 'stringarray'
+                ],
+                'matrix' => [
+                    'label' => Horde_Form_Translation::t("Values"),
+                    'type'  => 'stringarray'
+                ],
+                'new_input' => [
+                    'label' => Horde_Form_Translation::t("New Input"),
+                    'type'  => 'boolean'
+                ]
+            ]
+        ];
     }
 
 }
@@ -2523,7 +2551,7 @@ class Horde_Form_Type_mlenum extends Horde_Form_Type
             'params' => [
                 'values' => ['label' => Horde_Form_Translation::t("Values to select from"),
                     'type'  => 'stringarray'],
-                'prompt' => ['label' => Horde_Form_Translation::t("Prompt text"),
+                'prompts' => ['label' => Horde_Form_Translation::t("Prompt text"),
                     'type'  => 'text']]];
     }
 
@@ -2654,16 +2682,8 @@ class Horde_Form_Type_set extends Horde_Form_Type
      */
     public function init(...$params)
     {
-        if (is_array($params) && array_key_exists('values', $params)) {
-            $this->_values = $params['values'];
-        } else {
-            $this->_values = $params[0];
-        }
-        if (is_array($params) && array_key_exists('checkAll', $params)) {
-            $this->_checkAll = (bool) $params['checkAll'];
-        } else {
-            $this->_checkAll = $params[1] ?? false;
-        }
+        $this->_values = $params[0];
+        $this->_checkAll = $params[1] ?? false;
     }
 
     public function isValid($var, $vars, $value, $message)
@@ -2694,8 +2714,16 @@ class Horde_Form_Type_set extends Horde_Form_Type
         return [
             'name' => Horde_Form_Translation::t("Set"),
             'params' => [
-                'values' => ['label' => Horde_Form_Translation::t("Values"),
-                    'type'  => 'stringarray']]];
+                'values' => [
+                    'label' => Horde_Form_Translation::t("Values"),
+                    'type'  => 'stringarray'
+                ],
+                'checkAll' => [
+                    'label' => Horde_Form_Translation::t("Check all"),
+                    'type'  => 'boolean'
+                ]
+            ]
+        ];
     }
 
 }
@@ -2777,7 +2805,15 @@ class Horde_Form_Type_date extends Horde_Form_Type
      */
     public function about()
     {
-        return ['name' => Horde_Form_Translation::t("Date")];
+        return [
+            'name' => Horde_Form_Translation::t("Date"),
+            'params' => [
+                'format' => [
+                    'label' => Horde_Form_Translation::t("Format"),
+                    'type'  => 'string'
+                ]
+            ]
+        ];
     }
 
 }
@@ -2917,7 +2953,7 @@ class Horde_Form_Type_hourminutesecond extends Horde_Form_Type
         return [
             'name' => Horde_Form_Translation::t("Time selection"),
             'params' => [
-                'seconds' => ['label' => Horde_Form_Translation::t("Show seconds?"),
+                'show_seconds' => ['label' => Horde_Form_Translation::t("Show seconds?"),
                     'type'  => 'boolean']]];
     }
 
@@ -2935,8 +2971,8 @@ class Horde_Form_Type_monthyear extends Horde_Form_Type
      */
     public function init(...$params)
     {
-        $start_year = $params['start_year'] ?? $params[0] ?? null;
-        $end_year = $params['end_year'] ?? $params[1] ?? null;
+        $start_year = $params[0] ?? null;
+        $end_year = $params[1] ?? null;
 
         if (empty($start_year)) {
             $start_year = 1920;
@@ -3013,11 +3049,11 @@ class Horde_Form_Type_monthdayyear extends Horde_Form_Type
      */
     public function init(...$params)
     {
-        $start_year = $params['start_year'] ?? $params[0] ?? '';
-        $end_year = $params['end_year'] ?? $params[1] ?? '';
-        $picker = $params['picker'] ?? $params[2] ?? true;
-        $format_in = $params['format_in'] ?? $params[3] ?? null;
-        $format_out = $params['format_out'] ?? $params[4] ?? '%x';
+        $start_year = $params[0] ?? '';
+        $end_year = $params[1] ?? '';
+        $picker = $params[2] ?? true;
+        $format_in = $params[3] ?? null;
+        $format_out = $params[4] ?? '%x';
 
         if (empty($start_year)) {
             $start_year = date('Y');
@@ -3251,12 +3287,12 @@ class Horde_Form_Type_datetime extends Horde_Form_Type
      */
     public function init(...$params)
     {
-        $start_year = $params['start_year'] ?? $params[0] ?? '';
-        $end_year = $params['end_year'] ?? $params[1] ?? '';
-        $picker = $params['picker'] ?? $params[2] ?? true;
-        $format_in = $params['format_in'] ?? $params[3] ?? null;
-        $format_out = $params['format_out'] ?? $params[4] ?? '%x';
-        $show_seconds = $params['show_seconds'] ?? $params[5] ?? false;
+        $start_year = $params[0] ?? '';
+        $end_year = $params[1] ?? '';
+        $picker = $params[2] ?? true;
+        $format_in = $params[3] ?? null;
+        $format_out = $params[4] ?? '%x';
+        $show_seconds = $params[5] ?? false;
 
         $this->_mdy = new Horde_Form_Type_monthdayyear();
         $this->_mdy->init($start_year, $end_year, $picker, $format_in, $format_out);
@@ -3404,7 +3440,7 @@ class Horde_Form_Type_datetime extends Horde_Form_Type
                     'type'  => 'text'],
                 'format_out' => ['label' => Horde_Form_Translation::t("Display format"),
                     'type'  => 'text'],
-                'seconds'    => ['label' => Horde_Form_Translation::t("Show seconds?"),
+                'show_seconds' => ['label' => Horde_Form_Translation::t("Show seconds?"),
                     'type'  => 'boolean']]];
     }
 
@@ -3484,9 +3520,9 @@ class Horde_Form_Type_sorter extends Horde_Form_Type
      */
     public function init(...$params)
     {
-        $values = $params['values'] ?? $params[0];
-        $size = $params['size'] ?? $params[1] ?? 8;
-        $header = $params['header'] ?? $params[2] ?? '';
+        $values = $params[0];
+        $size = $params[1] ?? 8;
+        $header = $params[2] ?? '';
 
         static $horde_sorter_instance = 0;
 
@@ -3936,7 +3972,7 @@ class Horde_Form_Type_dblookup extends Horde_Form_Type_enum
         return [
             'name' => Horde_Form_Translation::t("Database lookup"),
             'params' => [
-                'dsn' => ['label' => Horde_Form_Translation::t("DSN (see http://pear.php.net/manual/en/package.database.db.intro-dsn.php)"),
+                'db' => ['label' => Horde_Form_Translation::t("DSN (see http://pear.php.net/manual/en/package.database.db.intro-dsn.php)"),
                     'type'  => 'text'],
                 'sql' => ['label' => Horde_Form_Translation::t("SQL statement for value lookups"),
                     'type'  => 'text'],
@@ -4065,12 +4101,28 @@ class Horde_Form_Type_invalid extends Horde_Form_Type
      */
     public function init(...$params)
     {
-        $this->message = $params['message'] ?? $params[0] ?? '';
+        $this->message = $params[0] ?? '';
     }
 
     public function isValid($var, $vars, $value, $message)
     {
         return false;
+    }
+
+    /**
+     * Return info about field type.
+     */
+    public function about()
+    {
+        return [
+            'name' => Horde_Form_Translation::t("Invalid"),
+            'params' => [
+                'message' => [
+                    'label' => Horde_Form_Translation::t("Text"),
+                    'type'  => 'text'
+                ]
+            ]
+        ];
     }
 
 }

--- a/src/V3/BaseVariable.php
+++ b/src/V3/BaseVariable.php
@@ -638,7 +638,7 @@ class BaseVariable implements Variable
 
     public function invalid(string $message): bool
     {
-        $this->message = Horde_Form_Translation::t($message);
+        $this->message = $message;
         return false;
     }
 

--- a/src/V3/DateVariable.php
+++ b/src/V3/DateVariable.php
@@ -81,7 +81,15 @@ class DateVariable extends BaseVariable
      */
     public function about(): array
     {
-        return [ 'name' => Horde_Form_Translation::t("Date") ];
+        return [
+            'name' => Horde_Form_Translation::t("Date"),
+            'params' => [
+                'format' => [
+                    'label' => Horde_Form_Translation::t("Format"),
+                    'type'  => 'string'
+                ]
+            ]
+        ];
     }
 
 }

--- a/src/V3/DatetimeVariable.php
+++ b/src/V3/DatetimeVariable.php
@@ -26,12 +26,12 @@ class DatetimeVariable extends BaseVariable
      */
     public function init(...$params)
     {
-        $start_year = $params['start_year'] ?? $params[0] ?? '';
-        $end_year = $params['end_year'] ?? $params[1] ?? '';
-        $picker = $params['picker'] ?? $params[2] ?? true;
-        $format_in = $params['format_in'] ?? $params[3] ?? null;
-        $format_out = $params['format_out'] ?? $params[4] ?? '%x';
-        $show_seconds = $params['show_seconds'] ?? $params[5] ?? false;
+        $start_year = $params[0] ?? '';
+        $end_year = $params[1] ?? '';
+        $picker = $params[2] ?? true;
+        $format_in = $params[3] ?? null;
+        $format_out = $params[4] ?? '%x';
+        $show_seconds = $params[5] ?? false;
 
         $this->_mdy = new MonthdayyearVariable('', '', true);
         $this->_mdy->init($start_year, $end_year, $picker, $format_in, $format_out);
@@ -169,7 +169,7 @@ class DatetimeVariable extends BaseVariable
                     'type'  => 'text'],
                 'format_out' => ['label' => Horde_Form_Translation::t("Display format"),
                     'type'  => 'text'],
-                'seconds'    => ['label' => Horde_Form_Translation::t("Show seconds?"),
+                'show_seconds'    => ['label' => Horde_Form_Translation::t("Show seconds?"),
                     'type'  => 'boolean']]];
     }
 

--- a/src/V3/DblookupVariable.php
+++ b/src/V3/DblookupVariable.php
@@ -37,7 +37,7 @@ class DblookupVariable extends EnumVariable
         return [
             'name' => Horde_Form_Translation::t("Database lookup"),
             'params' => [
-                'dsn' => [
+                'db' => [
                     'label' => Horde_Form_Translation::t("DSN (see http://pear.php.net/manual/en/package.database.db.intro-dsn.php)"),
                     'type'  => 'text'
                 ],

--- a/src/V3/HourminutesecondVariable.php
+++ b/src/V3/HourminutesecondVariable.php
@@ -113,7 +113,7 @@ class HourminutesecondVariable extends BaseVariable
         return [
             'name' => Horde_Form_Translation::t("Time selection"),
             'params' => [
-                'seconds' => [
+                'show_seconds' => [
                     'label' => Horde_Form_Translation::t("Show seconds?"),
                     'type'  => 'boolean'
                 ]

--- a/src/V3/InvalidVariable.php
+++ b/src/V3/InvalidVariable.php
@@ -12,12 +12,28 @@ class InvalidVariable extends BaseVariable
      */
     public function init(...$params)
     {
-        $this->message = $params['message'] ?? $params[0] ?? '';;
+        $this->message = $params[0] ?? '';
     }
 
     public function isValid(Horde_Variables|array $vars, $value): bool
     {
         return false;
+    }
+
+    /**
+     * Return info about field type.
+     */
+    public function about()
+    {
+        return [
+            'name' => Horde_Form_Translation::t("Invalid"),
+            'params' => [
+                'message' => [
+                    'label' => Horde_Form_Translation::t("Text"),
+                    'type'  => 'text'
+                ]
+            ]
+        ];
     }
 
 }

--- a/src/V3/LinkVariable.php
+++ b/src/V3/LinkVariable.php
@@ -36,35 +36,11 @@ class LinkVariable extends BaseVariable
         return [
             'name' => Horde_Form_Translation::t("Link"),
             'params' => [
-                'url' => [
-                    'label' => Horde_Form_Translation::t("Link URL"),
-                    'type' => 'text'
-                ],
-                'text' => [
-                    'label' => Horde_Form_Translation::t("Link text"),
-                    'type' => 'text'
-                ],
-                'target' => [
-                    'label' => Horde_Form_Translation::t("Link target"),
-                    'type' => 'text'
-                ],
-                'onclick' => [
-                    'label' => Horde_Form_Translation::t("Onclick event"),
-                    'type' => 'text'
-                ],
-                'title' => [
-                    'label' => Horde_Form_Translation::t("Link title attribute"),
-                    'type' => 'text'
-                ],
-                'accesskey' => [
-                    'label' => Horde_Form_Translation::t("Link access key"),
-                    'type' => 'text'
-                ],
-                'class' => [
-                    'label' => Horde_Form_Translation::t("Link CSS class"),
-                    'type' => 'text'
-                ],
-            ],
+               'values' => [
+                    'label' => Horde_Form_Translation::t("Values"),
+                    'type' => 'array'
+                ]
+            ]
         ];
     }
 

--- a/src/V3/MatrixVariable.php
+++ b/src/V3/MatrixVariable.php
@@ -84,6 +84,18 @@ class MatrixVariable extends BaseVariable
                 'cols' => [
                     'label' => Horde_Form_Translation::t("Column titles"),
                     'type'  => 'stringarray'
+                ],
+                'rows' => [
+                    'label' => Horde_Form_Translation::t("Row titles"),
+                    'type'  => 'stringarray'
+                ],
+                'matrix' => [
+                    'label' => Horde_Form_Translation::t("Values"),
+                    'type'  => 'stringarray'
+                ],
+                'new_input' => [
+                    'label' => Horde_Form_Translation::t("New Input"),
+                    'type'  => 'boolean'
                 ]
             ]
         ];

--- a/src/V3/MlenumVariable.php
+++ b/src/V3/MlenumVariable.php
@@ -19,9 +19,9 @@ class MlenumVariable extends BaseVariable
         $prompts = $params[1] ?? null;
 
         if ($prompts === true) {
-            $this->_prompts = [Horde_Form_Translation::t("-- select --"), Horde_Form_Translation::t("-- select --")];
+            $this->_prompts = [ Horde_Form_Translation::t("-- select --"), Horde_Form_Translation::t("-- select --") ];
         } elseif (!is_array($prompts)) {
-            $this->_prompts = [$prompts, $prompts];
+            $this->_prompts = [ $prompts, $prompts ];
         } else {
             $this->_prompts = $prompts;
         }
@@ -83,7 +83,7 @@ class MlenumVariable extends BaseVariable
                     'label' => Horde_Form_Translation::t("Values to select from"),
                     'type'  => 'stringarray'
                 ],
-                'prompt' => [
+                'prompts' => [
                     'label' => Horde_Form_Translation::t("Prompt text"),
                     'type'  => 'text'
                 ]

--- a/src/V3/MonthdayyearVariable.php
+++ b/src/V3/MonthdayyearVariable.php
@@ -29,11 +29,11 @@ class MonthdayyearVariable extends BaseVariable
      */
     public function init(...$params)
     {
-        $start_year = $params['start_year'] ?? $params[0] ?? '';
-        $end_year = $params['end_year'] ?? $params[1] ?? '';
-        $picker = $params['picker'] ?? $params[2] ?? true;
-        $format_in = $params['format_in'] ?? $params[3] ?? null;
-        $format_out = $params['format_out'] ?? $params[4] ?? '%x';
+        $start_year = $params[0] ?? '';
+        $end_year = $params[1] ?? '';
+        $picker = $params[2] ?? true;
+        $format_in = $params[3] ?? null;
+        $format_out = $params[4] ?? '%x';
 
         if (empty($start_year)) {
             $start_year = date('Y');

--- a/src/V3/MonthyearVariable.php
+++ b/src/V3/MonthyearVariable.php
@@ -15,8 +15,8 @@ class MonthyearVariable extends BaseVariable
      */
     public function init(...$params)
     {
-        $start_year = $params['start_year'] ?? $params[0] ?? null;
-        $end_year = $params['end_year'] ?? $params[1] ?? null;
+        $start_year = $params[0] ?? null;
+        $end_year = $params[1] ?? null;
 
         if (empty($start_year)) {
             $start_year = 1920;

--- a/src/V3/NumberVariable.php
+++ b/src/V3/NumberVariable.php
@@ -83,6 +83,14 @@ class NumberVariable extends BaseVariable
      */
     public function about(): array
     {
-        return [ 'name' => Horde_Form_Translation::t("Number") ];
+        return [
+            'name' => Horde_Form_Translation::t("Number"),
+            'params' => [
+                'fraction'  => [
+                    'label' => Horde_Form_Translation::t("Fraction"),
+                    'type'  => 'int'
+                ]
+            ]
+        ];
     }
 }

--- a/src/V3/SetVariable.php
+++ b/src/V3/SetVariable.php
@@ -15,16 +15,8 @@ class SetVariable extends BaseVariable
      */
     public function init(...$params)
     {
-        if (is_array($params) && array_key_exists('values', $params)) {
-            $this->_values = $params['values'];
-        } else {
-            $this->_values = $params[0];
-        }
-        if (is_array($params) && array_key_exists('checkAll', $params)) {
-            $this->_checkAll = (bool) $params['checkAll'];
-        } else {
-            $this->_checkAll = $params[1] ?? false;
-        }
+        $this->_values = $params[0];
+        $this->_checkAll = $params[1] ?? false;
     }
 
     public function isValid(Horde_Variables|array $vars, $value): bool
@@ -59,6 +51,10 @@ class SetVariable extends BaseVariable
                 'values' => [
                     'label' => Horde_Form_Translation::t("Values"),
                     'type'  => 'stringarray'
+                ],
+                'checkAll' => [
+                    'label' => Horde_Form_Translation::t("Check all"),
+                    'type'  => 'boolean'
                 ]
             ]
         ];

--- a/src/V3/SorterVariable.php
+++ b/src/V3/SorterVariable.php
@@ -15,9 +15,9 @@ class SorterVariable extends BaseVariable
      */
     public function init(...$params)
     {
-        $values = $params['values'] ?? $params[0];
-        $size = $params['size'] ?? $params[1] ?? 8;
-        $header = $params['header'] ?? $params[2] ?? '';
+        $values = $params[0];
+        $size = $params[1] ?? 8;
+        $header = $params[2] ?? '';
 
         static $horde_sorter_instance = 0;
 

--- a/src/V3/SpacerVariable.php
+++ b/src/V3/SpacerVariable.php
@@ -12,7 +12,9 @@ class SpacerVariable extends BaseVariable
 
     public function about(): array
     {
-        return [ 'name' => Horde_Form_Translation::t("Spacer") ];
+        return [
+            'name' => Horde_Form_Translation::t("Spacer")
+        ];
     }
 
 }

--- a/src/V3/Variable.php
+++ b/src/V3/Variable.php
@@ -53,5 +53,5 @@ interface Variable
     public function onSubmit($vars);
     //public function isValid(Horde_Variables|array $vars, $value): bool;
     public function getValues(...$params);
-    // TODO: Should about() be part of the interface?
+    public function about(): array;
 }


### PR DESCRIPTION
This is a proposed fix to #12:

I made `getType()` method private as it looks like this is not used anywhere outside of `Horde_Form`. And this is the only place where the named parameters could be passed (there is also two direct calls to `init()` in `Horde_Form_Type_datetime`, but these are _internal_ and they use positional parameters already).

I am using `params` from value returned by `about()`. I had to adjust it in a few places (non-critical change) to match original parameters names.

Later we could also add support for defaults by adding them to array returned by `about()` (and should not this method be static?). It is also possible to implement parameters type checks.

With the migration to `V3` this will all be reworked, anyway.