### PR TITLE
Create index(es) for optional named parameters in init() method

### DIFF
--- a/lib/Horde/Form.php
+++ b/lib/Horde/Form.php
@@ -188,11 +188,19 @@ class Horde_Form
             self::$init_params_cache[$type_class] = $keys;
         }
 
-        // convert named keys to numeric indexes
+        // convert named parameters to positional
         $i = 0;
+        $ni = 0;
         foreach ($keys as $key) {
             if (array_key_exists($key, $params)) {
-                $params[$i] = $params[$key];
+                // make sure prior index(es) exist
+                while ($ni < $i) {
+                    if (!array_key_exists($ni, $params)) {
+                        $params[$ni] = null;
+                    }
+                    ++$ni;
+                }
+                $params[$ni++] = $params[$key];
                 unset($params[$key]);
             }
             ++$i;


### PR DESCRIPTION
There is a possibility that some named parameters for `init()` would be omitted when passed to `addVariable()`/`addHidden()`/`insertVariableBefore()`.

Suppose we have this:
```php
function init(...$params) {
   $parm1 = $params[0];
   $parm2 = $params[1];
   ...
}
```
Calling `addVariable()` with `$params = [ 'parm1' => 'abc', 'parm2' => 123 ]` results in `init(...$params)` called with `$params = [ 0 => 'abc', 1 => 123 ]`, which is correct.

But if `parm1` is omitted, i.e. `$params = [ 'parm2' => 123 ]`, then `init(...$params)` would be called with `$params = [ 1 => 123 ]`. However PHP converts this internally to `$params = [ 0 => 123 ]`, which results in the wrong parameter assignment - `parm1` (not `parm2`) gets assigned `123`.

This PR addresses handling of omitted parameters (_we do not seem to have cases like that though_) by making sure indexes for such parameters exist.

With this PR the `params` in the previous example becomes `[ 0 => null, 1 => 123 ]`, which fixes the issue.