### PR TITLE
feat/separate compat interfaces from V3

### DIFF
--- a/src/V3/Action.php
+++ b/src/V3/Action.php
@@ -17,8 +17,6 @@ declare(strict_types=1);
 
 namespace Horde\Form\V3;
 
-use Horde\Form\Form;
-
 /**
  * The Action interface provides an API for adding actions to Form variables.
  *
@@ -28,12 +26,17 @@ use Horde\Form\Form;
  * - Perform calculations
  * - Trigger JavaScript behaviors
  *
+ * Extends both ActionMigrationInterface (lib/ compatibility methods)
+ * and ActionV3Interface (V3-native methods) to provide the complete
+ * Action API.
+ *
  * V3 improvements over lib/:
  * - Strict typing
  * - No singleton pattern (just use new)
  * - Named parameters
  * - Removed PHP 4 constructor
  * - Modern factory pattern
+ * - Added id() method for action tracking
  *
  * @author    Chuck Hagenbuch <chuck@horde.org>
  * @author    Ralf Lang <ralf.lang@ralf-lang.de>
@@ -43,65 +46,6 @@ use Horde\Form\Form;
  * @license   http://www.horde.org/licenses/lgpl21 LGPL 2.1
  * @package   Form
  */
-interface Action
+interface Action extends ActionMigrationInterface, ActionV3Interface
 {
-    /**
-     * Get action trigger events.
-     *
-     * @return array<string>|null  Event names (e.g., ['onload', 'onchange']) or null
-      *
-      * @api
-     */
-    public function getTrigger(): ?array;
-
-    /**
-     * Get action ID.
-     *
-     * @return string  Unique action identifier
-      *
-      * @api
-     */
-    public function id(): string;
-
-    /**
-     * Get JavaScript code for this action.
-     *
-     * @param Form $form  The form instance
-     * @param mixed $renderer  The form renderer
-     * @param string $varname  Variable name this action applies to
-     * @return string  JavaScript code
-      *
-      * @api
-     */
-    public function getActionScript(Form $form, $renderer, string $varname): string;
-
-    /**
-     * Print JavaScript for this action.
-     *
-     * Some actions may need to output JavaScript directly.
-      *
-      * @api
-     */
-    public function printJavaScript(): void;
-
-    /**
-     * Get target field name for this action.
-     *
-     * @return string|null  Target field name or null
-      *
-      * @api
-     */
-    public function getTarget(): ?string;
-
-    /**
-     * Set values based on action logic.
-     *
-     * @param mixed $vars  Form variables
-     * @param mixed $sourceVal  Source value
-     * @param int|null $index  Array index (if applicable)
-     * @param bool $arrayVal  Whether value is an array
-      *
-      * @api
-     */
-    public function setValues($vars, $sourceVal, ?int $index = null, bool $arrayVal = false): void;
 }

--- a/src/V3/Action.php
+++ b/src/V3/Action.php
@@ -49,6 +49,8 @@ interface Action
      * Get action trigger events.
      *
      * @return array<string>|null  Event names (e.g., ['onload', 'onchange']) or null
+      *
+      * @api
      */
     public function getTrigger(): ?array;
 
@@ -56,6 +58,8 @@ interface Action
      * Get action ID.
      *
      * @return string  Unique action identifier
+      *
+      * @api
      */
     public function id(): string;
 
@@ -66,6 +70,8 @@ interface Action
      * @param mixed $renderer  The form renderer
      * @param string $varname  Variable name this action applies to
      * @return string  JavaScript code
+      *
+      * @api
      */
     public function getActionScript(Form $form, $renderer, string $varname): string;
 
@@ -73,6 +79,8 @@ interface Action
      * Print JavaScript for this action.
      *
      * Some actions may need to output JavaScript directly.
+      *
+      * @api
      */
     public function printJavaScript(): void;
 
@@ -80,6 +88,8 @@ interface Action
      * Get target field name for this action.
      *
      * @return string|null  Target field name or null
+      *
+      * @api
      */
     public function getTarget(): ?string;
 
@@ -90,6 +100,8 @@ interface Action
      * @param mixed $sourceVal  Source value
      * @param int|null $index  Array index (if applicable)
      * @param bool $arrayVal  Whether value is an array
+      *
+      * @api
      */
     public function setValues($vars, $sourceVal, ?int $index = null, bool $arrayVal = false): void;
 }

--- a/src/V3/ActionMigrationInterface.php
+++ b/src/V3/ActionMigrationInterface.php
@@ -1,0 +1,73 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Copyright 2002-2026 Horde LLC (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (LGPL). If you
+ * did not receive this file, see http://www.horde.org/licenses/lgpl21.
+ *
+ * @author   Chuck Hagenbuch <chuck@horde.org>
+ * @category Horde
+ * @license  http://www.horde.org/licenses/lgpl21 LGPL 2.1
+ * @package  Form
+ */
+
+namespace Horde\Form\V3;
+
+use Horde\Form\Form;
+
+/**
+ * Migration interface for Action methods that existed in lib/ (Horde_Form_Action).
+ *
+ * These methods provide backward compatibility with the lib/ implementation.
+ * Code migrating from lib/ to V3 can rely on these methods having similar
+ * signatures and behavior.
+ *
+ * @category Horde
+ * @package  Form
+ */
+interface ActionMigrationInterface
+{
+    /**
+     * Get action trigger events.
+     *
+     * @return array<string>|null  Event names (e.g., ['onload', 'onchange']) or null
+     */
+    public function getTrigger(): ?array;
+
+    /**
+     * Get JavaScript code for this action.
+     *
+     * @param Form $form       The form instance
+     * @param mixed $renderer  The form renderer
+     * @param string $varname  Variable name this action applies to
+     *
+     * @return string  JavaScript code
+     */
+    public function getActionScript(Form $form, $renderer, string $varname): string;
+
+    /**
+     * Print JavaScript for this action.
+     *
+     * Some actions may need to output JavaScript directly.
+     */
+    public function printJavaScript(): void;
+
+    /**
+     * Get target field name for this action.
+     *
+     * @return string|null  Target field name or null
+     */
+    public function getTarget(): ?string;
+
+    /**
+     * Set values based on action logic.
+     *
+     * @param mixed $vars       Form variables
+     * @param mixed $sourceVal  Source value
+     * @param int|null $index   Array index (if applicable)
+     * @param bool $arrayVal    Whether value is an array
+     */
+    public function setValues($vars, $sourceVal, ?int $index = null, bool $arrayVal = false): void;
+}

--- a/src/V3/ActionV3Interface.php
+++ b/src/V3/ActionV3Interface.php
@@ -1,0 +1,38 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Copyright 2002-2026 Horde LLC (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (LGPL). If you
+ * did not receive this file, see http://www.horde.org/licenses/lgpl21.
+ *
+ * @author   Chuck Hagenbuch <chuck@horde.org>
+ * @category Horde
+ * @license  http://www.horde.org/licenses/lgpl21 LGPL 2.1
+ * @package  Form
+ */
+
+namespace Horde\Form\V3;
+
+/**
+ * V3-native interface for Action methods introduced in the V3 implementation.
+ *
+ * These methods are new to V3 and provide modernized functionality
+ * not present in lib/ (Horde_Form_Action).
+ *
+ * @category Horde
+ * @package  Form
+ */
+interface ActionV3Interface
+{
+    /**
+     * Get action ID.
+     *
+     * Returns a unique identifier for this action instance. This is new
+     * in V3 for better action tracking and debugging.
+     *
+     * @return string  Unique action identifier
+     */
+    public function id(): string;
+}

--- a/src/V3/AddressVariable.php
+++ b/src/V3/AddressVariable.php
@@ -111,6 +111,8 @@ class AddressVariable extends LongtextVariable
 
     /**
      * Return info about field type.
+      *
+      * @api
      */
     public function about(): array
     {

--- a/src/V3/AddresslinkVariable.php
+++ b/src/V3/AddresslinkVariable.php
@@ -23,6 +23,8 @@ class AddresslinkVariable extends AddressVariable
 
     /**
      * Return info about field type.
+      *
+      * @api
      */
     public function about(): array
     {

--- a/src/V3/AssignVariable.php
+++ b/src/V3/AssignVariable.php
@@ -33,6 +33,8 @@ class AssignVariable extends BaseVariable
      *                      - $params[3]: string $rightHeader - Right column header (default: '')
      *                      - $params[4]: int $size - Number of visible rows (default: 8)
      *                      - $params[5]: string $width - Width in CSS units (default: '200px')
+      *
+      * @api
      */
     public function init(...$params)
     {
@@ -54,6 +56,8 @@ class AssignVariable extends BaseVariable
      *
      * @param array $params Variable arguments:
      *                      - $params[0]: mixed $side - Which side to get values for (empty/0 = right, truthy = left)
+      *
+      * @api
      */
     public function getValues(...$params): ?array
     {
@@ -144,6 +148,8 @@ class AssignVariable extends BaseVariable
 
     /**
      * Return info about field type.
+      *
+      * @api
      */
     public function about(): array
     {

--- a/src/V3/BaseAction.php
+++ b/src/V3/BaseAction.php
@@ -65,6 +65,8 @@ abstract class BaseAction implements Action
      * Create a new action.
      *
      * @param array<string, mixed>|null $params  Action parameters
+      *
+      * @api
      */
     public function __construct(?array $params = null)
     {
@@ -76,6 +78,8 @@ abstract class BaseAction implements Action
      * Get action trigger events.
      *
      * @return array<string>|null  Event names or null
+      *
+      * @api
      */
     public function getTrigger(): ?array
     {
@@ -84,6 +88,8 @@ abstract class BaseAction implements Action
 
     /**
      * Get action ID.
+      *
+      * @api
      */
     public function id(): string
     {
@@ -99,6 +105,8 @@ abstract class BaseAction implements Action
      * @param mixed $renderer  The form renderer
      * @param string $varname  Variable name
      * @return string  JavaScript code
+      *
+      * @api
      */
     public function getActionScript(Form $form, $renderer, string $varname): string
     {
@@ -109,6 +117,8 @@ abstract class BaseAction implements Action
      * Print JavaScript for this action.
      *
      * Default implementation does nothing. Subclasses override if needed.
+      *
+      * @api
      */
     public function printJavaScript(): void
     {
@@ -119,6 +129,8 @@ abstract class BaseAction implements Action
      * Get target field name for this action.
      *
      * @return string|null  Target field name or null
+      *
+      * @api
      */
     public function getTarget(): ?string
     {
@@ -134,6 +146,8 @@ abstract class BaseAction implements Action
      * @param mixed $sourceVal  Source value
      * @param int|null $index  Array index (if applicable)
      * @param bool $arrayVal  Whether value is an array
+      *
+      * @api
      */
     public function setValues($vars, $sourceVal, ?int $index = null, bool $arrayVal = false): void
     {
@@ -154,6 +168,8 @@ abstract class BaseAction implements Action
      * @param array<string, mixed>|null $params  Action parameters
      * @return Action  Created action instance
      * @throws \InvalidArgumentException  If action class not found
+      *
+      * @api
      */
     public static function factory(string|array $action, ?array $params = null): Action
     {

--- a/src/V3/BaseForm.php
+++ b/src/V3/BaseForm.php
@@ -149,6 +149,8 @@ class BaseForm implements \Horde\Form\Form
      * @param Horde_Variables|ServerRequestInterface|array $vars  Form data
      * @param string $title  Form display title
      * @param string|null $name  Form name (auto-generated from class if null)
+      *
+      * @api
      */
     public function __construct(
         Horde_Variables|ServerRequestInterface|array $vars,
@@ -177,6 +179,8 @@ class BaseForm implements \Horde\Form\Form
      *
      * @param Horde_Variables|ServerRequestInterface|array $vars
      * @return array<string, mixed>
+      *
+      * @internal
      */
     private function normalizeVars(
         Horde_Variables|ServerRequestInterface|array $vars
@@ -194,6 +198,8 @@ class BaseForm implements \Horde\Form\Form
      * Returns a copy to prevent external mutation.
      *
      * @return array<string, mixed>
+      *
+      * @api
      */
     public function getVars(): array
     {
@@ -206,6 +212,8 @@ class BaseForm implements \Horde\Form\Form
      * Replaces all form data. Accepts same types as constructor.
      *
      * @param Horde_Variables|ServerRequestInterface|array $vars
+      *
+      * @api
      */
     public function setVars(Horde_Variables|ServerRequestInterface|array $vars): void
     {
@@ -218,6 +226,8 @@ class BaseForm implements \Horde\Form\Form
      * @param string $name  Variable name
      * @param mixed $default  Default value if not set
      * @return mixed  Variable value or default
+      *
+      * @api
      */
     public function getVar(string $name, mixed $default = null): mixed
     {
@@ -231,6 +241,8 @@ class BaseForm implements \Horde\Form\Form
      *
      * @param string $name  Variable name
      * @param mixed $value  Variable value
+      *
+      * @api
      */
     public function setVar(string $name, mixed $value): void
     {
@@ -239,6 +251,8 @@ class BaseForm implements \Horde\Form\Form
 
     /**
      * Get form title.
+      *
+      * @api
      */
     public function getTitle(): string
     {
@@ -247,6 +261,8 @@ class BaseForm implements \Horde\Form\Form
 
     /**
      * Set form title.
+      *
+      * @api
      */
     public function setTitle(string $title): void
     {
@@ -255,6 +271,8 @@ class BaseForm implements \Horde\Form\Form
 
     /**
      * Get extra form content.
+      *
+      * @api
      */
     public function getExtra(): string
     {
@@ -263,6 +281,8 @@ class BaseForm implements \Horde\Form\Form
 
     /**
      * Set extra form content (HTML, etc.).
+      *
+      * @api
      */
     public function setExtra(string $extra): void
     {
@@ -271,6 +291,8 @@ class BaseForm implements \Horde\Form\Form
 
     /**
      * Get form name.
+      *
+      * @api
      */
     public function getName(): string
     {
@@ -282,6 +304,8 @@ class BaseForm implements \Horde\Form\Form
      *
      * @param bool|null $token  If specified, sets whether to use tokens
      * @return bool  Current token usage setting
+      *
+      * @api
      */
     public function useToken(?bool $token = null): bool
     {
@@ -300,6 +324,8 @@ class BaseForm implements \Horde\Form\Form
      * @param string $desc  Section description
      * @param string $image  Section icon/image URL
      * @param bool $expanded  Whether section starts expanded
+      *
+      * @api
      */
     public function setSection(
         string|int $section = '',
@@ -321,6 +347,8 @@ class BaseForm implements \Horde\Form\Form
 
     /**
      * Get section description.
+      *
+      * @api
      */
     public function getSectionDesc(string|int $section): string
     {
@@ -329,6 +357,8 @@ class BaseForm implements \Horde\Form\Form
 
     /**
      * Get section image/icon URL.
+      *
+      * @api
      */
     public function getSectionImage(string|int $section): string
     {
@@ -339,6 +369,8 @@ class BaseForm implements \Horde\Form\Form
      * Set which section is currently open.
      *
      * @param string|int $section  Section identifier
+      *
+      * @api
      */
     public function setOpenSection(string|int $section): void
     {
@@ -349,6 +381,8 @@ class BaseForm implements \Horde\Form\Form
      * Get which section is currently open.
      *
      * @return string|int|null  Open section identifier or null
+      *
+      * @api
      */
     public function getOpenSection(): string|int|null
     {
@@ -361,6 +395,8 @@ class BaseForm implements \Horde\Form\Form
      * @param string|int $section  Section identifier
      * @param bool $boolean  If true, return bool; if false, return CSS value
      * @return bool|string  Expanded state as bool or 'block'/'none' for CSS
+      *
+      * @api
      */
     public function getSectionExpandedState(string|int $section, bool $boolean = false): bool|string
     {
@@ -386,6 +422,8 @@ class BaseForm implements \Horde\Form\Form
      * @param string|null $description  Field description/help text
      * @param array $params  Type-specific parameters (e.g., enum values)
      * @return Variable  The created variable instance
+      *
+      * @api
      */
     public function addVariable(
         string $humanName,
@@ -422,6 +460,8 @@ class BaseForm implements \Horde\Form\Form
      * @param string|null $description  Field description/help text
      * @param array $params  Type-specific parameters
      * @return Variable  The created variable instance
+      *
+      * @api
      */
     public function insertVariableBefore(
         ?string $before,
@@ -514,6 +554,8 @@ class BaseForm implements \Horde\Form\Form
      * @param string|null $description  Field description
      * @param array $params  Type-specific parameters
      * @return Variable  Created variable instance
+      *
+      * @internal
      */
     private function createVariable(
         string $humanName,
@@ -559,6 +601,8 @@ class BaseForm implements \Horde\Form\Form
      *
      * @param Variable|string $var  Variable instance or variable name
      * @return bool  True if variable was found and removed
+      *
+      * @api
      */
     public function removeVariable(Variable|string $var): bool
     {
@@ -591,6 +635,8 @@ class BaseForm implements \Horde\Form\Form
      * @param string|null $description  Field description
      * @param array $params  Type-specific parameters
      * @return Variable  The created variable instance
+      *
+      * @api
      */
     public function addHidden(
         string $humanName,
@@ -623,6 +669,8 @@ class BaseForm implements \Horde\Form\Form
      * @param bool $flat  If true, return flat array; if false, return by section
      * @param bool $withHidden  If true, include hidden variables
      * @return array<Variable>|array<string, array<Variable>>
+      *
+      * @api
      */
     public function getVariables(bool $flat = true, bool $withHidden = false): array
     {
@@ -649,6 +697,8 @@ class BaseForm implements \Horde\Form\Form
      *
      * @param array<string>|string|bool $submit  Submit button label(s) or true for default
      * @param string|bool $reset  Reset button label or false for none
+      *
+      * @api
      */
     public function setButtons(array|string|bool $submit, string|bool $reset = false): void
     {
@@ -671,6 +721,8 @@ class BaseForm implements \Horde\Form\Form
      * Append additional submit buttons.
      *
      * @param array<string>|string $submit  Button label(s) to append
+      *
+      * @api
      */
     public function appendButtons(array|string $submit): void
     {
@@ -688,6 +740,8 @@ class BaseForm implements \Horde\Form\Form
      *
      * @param mixed $vars  Optional variables to validate against (null = use form's vars)
      * @return bool  True if validation passed, false if errors exist
+      *
+      * @api
      */
     public function validate($vars = null): bool
     {
@@ -734,6 +788,8 @@ class BaseForm implements \Horde\Form\Form
      * Must call validate() first.
      *
      * @return bool  True if no validation errors exist
+      *
+      * @api
      */
     public function isValid(): bool
     {
@@ -744,6 +800,8 @@ class BaseForm implements \Horde\Form\Form
      * Get validation errors.
      *
      * @return array<string, string>  Map of variable name => error message
+      *
+      * @api
      */
     public function getErrors(): array
     {
@@ -755,6 +813,8 @@ class BaseForm implements \Horde\Form\Form
      *
      * @param string $varName  Variable name
      * @return string|null  Error message or null if no error
+      *
+      * @api
      */
     public function getError(string $varName): ?string
     {
@@ -766,6 +826,8 @@ class BaseForm implements \Horde\Form\Form
      *
      * @param string $varName  Variable name
      * @param string $message  Error message
+      *
+      * @api
      */
     public function setError(string $varName, string $message): void
     {
@@ -776,6 +838,8 @@ class BaseForm implements \Horde\Form\Form
      * Clear all errors or error for specific variable.
      *
      * @param string|null $varName  Variable name to clear (null = clear all)
+      *
+      * @api
      */
     public function clearError(?string $varName = null): void
     {
@@ -793,6 +857,8 @@ class BaseForm implements \Horde\Form\Form
      *
      * @param mixed $vars  Optional variables to extract from (null = use form's vars)
      * @return array<string, mixed>  Associative array of field name => value
+      *
+      * @api
      */
     public function getInfo($vars = null): array
     {
@@ -817,6 +883,8 @@ class BaseForm implements \Horde\Form\Form
      * @param array<Variable> $variables  Variables to extract from
      * @param array $vars  Variable data
      * @return array<string, mixed>  Extracted field values
+      *
+      * @internal
      */
     private function getInfoFromVariables(array $variables, array $vars): array
     {
@@ -848,6 +916,8 @@ class BaseForm implements \Horde\Form\Form
      * Check if form has been submitted.
      *
      * @return bool  True if form was submitted
+      *
+      * @api
      */
     public function isSubmitted(): bool
     {
@@ -867,6 +937,8 @@ class BaseForm implements \Horde\Form\Form
      * Get form encoding type.
      *
      * @return string|null  Encoding type (e.g., 'multipart/form-data') or null
+      *
+      * @api
      */
     public function getEnctype(): ?string
     {

--- a/src/V3/BaseRenderer.php
+++ b/src/V3/BaseRenderer.php
@@ -105,6 +105,8 @@ abstract class BaseRenderer implements Renderer
      * @param ErrorRenderer|null $errorRenderer  Error renderer
      * @param AssetManager|null $assetManager  Asset manager
      * @param array<string, mixed> $config  Configuration options
+      *
+      * @api
      */
     public function __construct(
         ?ControlRenderer $controlRenderer = null,
@@ -169,6 +171,8 @@ abstract class BaseRenderer implements Renderer
      * Render the complete form.
      *
      * Template method - defines the rendering flow.
+      *
+      * @api
      */
     public function render(Form $form, string $action = '', string $method = 'post'): string
     {
@@ -233,6 +237,8 @@ abstract class BaseRenderer implements Renderer
      * @param array<Variable> $variables  Variables to render
      * @param Form $form  Parent form
      * @return string  Rendered variables
+      *
+      * @internal
      */
     protected function renderVariables(array $variables, Form $form): string
     {
@@ -245,6 +251,8 @@ abstract class BaseRenderer implements Renderer
 
     /**
      * Render a single variable.
+      *
+      * @api
      */
     public function renderVariable(Variable $variable, Form $form): string
     {
@@ -281,6 +289,8 @@ abstract class BaseRenderer implements Renderer
 
     /**
      * Render a form section.
+      *
+      * @api
      */
     public function renderSection(string|int $sectionName, array $variables, Form $form): string
     {
@@ -299,6 +309,8 @@ abstract class BaseRenderer implements Renderer
 
     /**
      * Render validation errors.
+      *
+      * @api
      */
     public function renderErrors(Form $form): string
     {
@@ -312,6 +324,8 @@ abstract class BaseRenderer implements Renderer
 
     /**
      * Render hidden fields.
+      *
+      * @api
      */
     public function renderHidden(Form $form): string
     {
@@ -345,6 +359,8 @@ abstract class BaseRenderer implements Renderer
      * Get CSS class for current row (for striped rows).
      *
      * @return string  CSS class
+      *
+      * @internal
      */
     protected function getRowClass(): string
     {
@@ -362,6 +378,8 @@ abstract class BaseRenderer implements Renderer
      * @param array<string, mixed> $attrs  Attributes (null values are skipped)
      * @param string|null $content  Tag content (null = self-closing)
      * @return string  HTML tag
+      *
+      * @internal
      */
     protected function buildTag(string $tag, array $attrs = [], ?string $content = null): string
     {
@@ -387,6 +405,8 @@ abstract class BaseRenderer implements Renderer
 
     /**
      * Set whether to show form header.
+      *
+      * @api
      */
     public function setShowHeader(bool $show): void
     {
@@ -395,6 +415,8 @@ abstract class BaseRenderer implements Renderer
 
     /**
      * Set required field marker.
+      *
+      * @api
      */
     public function setRequiredMarker(string $marker): void
     {
@@ -403,6 +425,8 @@ abstract class BaseRenderer implements Renderer
 
     /**
      * Set help text marker.
+      *
+      * @api
      */
     public function setHelpMarker(string $marker): void
     {
@@ -411,6 +435,8 @@ abstract class BaseRenderer implements Renderer
 
     /**
      * Set whether to encode form title.
+      *
+      * @api
      */
     public function setEncodeTitle(bool $encode): void
     {
@@ -419,6 +445,8 @@ abstract class BaseRenderer implements Renderer
 
     /**
      * Get control renderer.
+      *
+      * @api
      */
     public function getControlRenderer(): ControlRenderer
     {
@@ -427,6 +455,8 @@ abstract class BaseRenderer implements Renderer
 
     /**
      * Get layout strategy.
+      *
+      * @api
      */
     public function getLayoutStrategy(): LayoutStrategy
     {
@@ -435,6 +465,8 @@ abstract class BaseRenderer implements Renderer
 
     /**
      * Get error renderer.
+      *
+      * @api
      */
     public function getErrorRenderer(): ErrorRenderer
     {
@@ -443,6 +475,8 @@ abstract class BaseRenderer implements Renderer
 
     /**
      * Get asset manager.
+      *
+      * @api
      */
     public function getAssetManager(): AssetManager
     {

--- a/src/V3/BaseVariable.php
+++ b/src/V3/BaseVariable.php
@@ -128,11 +128,29 @@ class BaseVariable implements Variable
      */
     protected string $message = '';
 
+    /**
+     * Returns the validation error message.
+     *
+     * @return string  The validation error message
+     *
+     * @api
+     */
     public function getMessage()
     {
         return $this->message;
     }
 
+    /**
+     * Creates a new form variable.
+     *
+     * @param string $humanName    Short description of the variable's purpose
+     * @param string $varName      Internally used variable name
+     * @param bool $required       Whether this is a required variable
+     * @param bool $readonly       Whether this is a readonly variable
+     * @param string|null $description  Long description, special instructions, etc.
+     *
+     * @api
+     */
     public function __construct(
         $humanName,
         $varName,
@@ -153,6 +171,8 @@ class BaseVariable implements Variable
      * Assign this variable to the specified form.
      *
      * @param Horde_Form $form  The form instance to assign this variable to.
+      *
+      * @api
      */
     public function setFormOb($form)
     {
@@ -163,6 +183,8 @@ class BaseVariable implements Variable
      * Sets a default value for this variable.
      *
      * @param mixed $value  A variable value.
+      *
+      * @api
      */
     public function setDefault($value)
     {
@@ -173,6 +195,8 @@ class BaseVariable implements Variable
      * Returns this variable's default value.
      *
      * @return mixed  This variable's default value.
+      *
+      * @api
      */
     public function getDefault()
     {
@@ -189,6 +213,8 @@ class BaseVariable implements Variable
      * ```
      *
      * @param Action $action  An {@link Action} instance.
+      *
+      * @api
      */
     public function setAction($action)
     {
@@ -199,6 +225,8 @@ class BaseVariable implements Variable
      * Returns whether this variable has an attached action.
      *
      * @return boolean  True if this variable has an attached action.
+      *
+      * @api
      */
     public function hasAction()
     {
@@ -207,6 +235,8 @@ class BaseVariable implements Variable
 
     /**
      * Makes this a hidden variable.
+      *
+      * @api
      */
     public function hide()
     {
@@ -217,6 +247,8 @@ class BaseVariable implements Variable
      * Returns whether this is a hidden variable.
      *
      * @return boolean  True if this a hidden variable.
+      *
+      * @api
      */
     public function isHidden()
     {
@@ -230,6 +262,8 @@ class BaseVariable implements Variable
      * during form processing and validation.
      *
      * @return void
+      *
+      * @api
      */
     public function disable()
     {
@@ -240,6 +274,8 @@ class BaseVariable implements Variable
      * Returns whether this variable is disabled.
      *
      * @return boolean  True if this variable is disabled.
+      *
+      * @api
      */
     public function isDisabled()
     {
@@ -250,6 +286,8 @@ class BaseVariable implements Variable
      * Return the short description of this variable.
      *
      * @return string  A short description
+      *
+      * @api
      */
     public function getHumanName()
     {
@@ -260,6 +298,8 @@ class BaseVariable implements Variable
      * Returns the internally used variable name.
      *
      * @return string  This variable's internal name.
+      *
+      * @api
      */
     public function getVarName()
     {
@@ -285,6 +325,8 @@ class BaseVariable implements Variable
      * @return string  This variable's {@link Horde_Form_Type} name.
      *
      * Override with a simple return 'literal' string in your own types.
+      *
+      * @api
      */
     public function getTypeName(): string
     {
@@ -295,6 +337,8 @@ class BaseVariable implements Variable
      * Returns whether this is a required variable.
      *
      * @return boolean  True if this is a required variable.
+      *
+      * @api
      */
     public function isRequired()
     {
@@ -305,6 +349,8 @@ class BaseVariable implements Variable
      * Returns whether this is a readonly variable.
      *
      * @return boolean  True if this a readonly variable.
+      *
+      * @api
      */
     public function isReadonly()
     {
@@ -315,6 +361,8 @@ class BaseVariable implements Variable
      * Returns the possible values of this variable.
      *
      * @return array  The possible values of this variable or null.
+      *
+      * @api
      */
     public function getValues(...$params): ?array
     {
@@ -325,6 +373,8 @@ class BaseVariable implements Variable
      * Returns whether this variable has a long description.
      *
      * @return boolean  True if this variable has a long description.
+      *
+      * @api
      */
     public function hasDescription(): bool
     {
@@ -335,6 +385,8 @@ class BaseVariable implements Variable
      * Returns this variable's long description.
      *
      * @return string  This variable's long description.
+      *
+      * @api
      */
     public function getDescription()
     {
@@ -345,6 +397,8 @@ class BaseVariable implements Variable
      * Returns whether this is an array variable.
      *
      * @return boolean  True if this an array variable.
+      *
+      * @api
      */
     public function isArrayVal()
     {
@@ -355,6 +409,8 @@ class BaseVariable implements Variable
      * Returns whether this variable is to upload a file.
      *
      * @return boolean  True if variable is to upload a file.
+      *
+      * @api
      */
     public function isUpload()
     {
@@ -365,6 +421,8 @@ class BaseVariable implements Variable
      * Assigns a help text to this variable.
      *
      * @param string $help  The variable help text.
+      *
+      * @api
      */
     public function setHelp($help)
     {
@@ -376,6 +434,8 @@ class BaseVariable implements Variable
      * Returns whether this variable has some help text assigned.
      *
      * @return boolean  True if this variable has a help text.
+      *
+      * @api
      */
     public function hasHelp()
     {
@@ -386,6 +446,8 @@ class BaseVariable implements Variable
      * Returns the help text of this variable.
      *
      * @return string  This variable's help text.
+      *
+      * @api
      */
     public function getHelp()
     {
@@ -397,6 +459,8 @@ class BaseVariable implements Variable
      *
      * @param string $option  The option name.
      * @param mixed $val      The option's value.
+      *
+      * @api
      */
     public function setOption($option, $val)
     {
@@ -409,6 +473,8 @@ class BaseVariable implements Variable
      * @param string $option  The option name.
      *
      * @return mixed          The option's value.
+      *
+      * @api
      */
     public function getOption($option)
     {
@@ -435,6 +501,8 @@ class BaseVariable implements Variable
      * @param mixed ...$args  Ignored (for interface compatibility)
      * @return mixed  The variable value
      * @deprecated The second parameter ($info) is deprecated/ignored
+      *
+      * @api
      */
     public function getInfo($vars, ...$args) {
         if (count($args) > 0) {
@@ -443,6 +511,18 @@ class BaseVariable implements Variable
         return $this->getInfoV3($vars);
     }
 
+    /**
+     * Extract variable value from form variables.
+     *
+     * Internal method used by getInfo() wrapper. Subclasses override this
+     * to provide type-specific value extraction logic.
+     *
+     * @param Horde_Variables $vars  Form variables
+     *
+     * @return mixed  Extracted value
+     *
+     * @internal
+     */
     //TODO: Rename back to getInfo() after the V3 transition
     protected function getInfoV3($vars)
     {
@@ -459,6 +539,8 @@ class BaseVariable implements Variable
      * @return ?boolean Null if this variable doesn't have the "trackchange"
      *                  option set or the form wasn't submitted yet. A boolean
      *                  indicating whether the variable was changed otherwise.
+      *
+      * @api
      */
     public function wasChanged($vars)
     {
@@ -479,6 +561,8 @@ class BaseVariable implements Variable
      *                         form.
      *
      * @return boolean  True if the variable validated.
+      *
+      * @api
      */
     public function validate($vars, ...$args)
     {
@@ -596,6 +680,8 @@ class BaseVariable implements Variable
      * @param string $property  Property name (without underscore prefix)
      *
      * @return mixed  Property value, or null if not set
+      *
+      * @api
      */
     public function getProperty($property)
     {
@@ -635,6 +721,8 @@ class BaseVariable implements Variable
      * @param mixed $value      Value to set
      *
      * @return void
+      *
+      * @api
      */
     public function setProperty($property, $value)
     {
@@ -659,6 +747,8 @@ class BaseVariable implements Variable
 
     /**
      * Initialize (kind of constructor) - Parameter list may vary on overloading
+      *
+      * @api
      */
     public function init(...$params) {}
 
@@ -672,11 +762,15 @@ class BaseVariable implements Variable
      * @param Horde_Variables $vars  Submitted form variables
      *
      * @return void
+      *
+      * @api
      */
     public function onSubmit($vars) {}
 
     /**
      * Use $this->getMessage() to retrieve error messages.
+      *
+      * @internal
      */
     protected function isValid(Horde_Variables $vars, $value): bool
     {

--- a/src/V3/BaseVariable.php
+++ b/src/V3/BaseVariable.php
@@ -429,8 +429,12 @@ class BaseVariable implements Variable
      * @param Horde_Variables $vars  The variables object
      * @param mixed ...$args  Ignored (for interface compatibility)
      * @return mixed  The variable value
+     * @deprecated The second parameter ($info) is deprecated/ignored
      */
     public function getInfo($vars, ...$args) {
+        if (count($args) > 0) {
+            self::Deprecated('Warning: The second ($info) parameter in getInfo() is deprecated/ignored');
+        }
         return $this->getInfoV3($vars);
     }
 

--- a/src/V3/BaseVariable.php
+++ b/src/V3/BaseVariable.php
@@ -225,6 +225,11 @@ class BaseVariable implements Variable
 
     /**
      * Disables this variable.
+     *
+     * Disabled fields are not submitted by browsers and are skipped
+     * during form processing and validation.
+     *
+     * @return void
      */
     public function disable()
     {
@@ -559,7 +564,19 @@ class BaseVariable implements Variable
 
     // Former Type-related methods
 
-    //TODO: Does not belong here
+    /**
+     * Logs a deprecation warning message.
+     *
+     * Helper method for logging deprecation warnings during the lib/ to V3
+     * migration. Includes file and line number from the call stack.
+     *
+     * @param string $message  The deprecation warning message
+     * @param int $level       Stack trace depth (default: 2)
+     *
+     * @return void
+     *
+     * @todo This method should be removed after V3 transition is complete
+     */
     public static function Deprecated($message, $level = 2) {
         $trace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, $level + 1);
         if (isset($trace[$level])) {
@@ -570,6 +587,16 @@ class BaseVariable implements Variable
         Horde::log($message, 'WARN');
     }
 
+    /**
+     * Gets internal property value by name.
+     *
+     * Accesses internal properties using underscore-prefixed naming convention
+     * (e.g., 'size' accesses $this->_size).
+     *
+     * @param string $property  Property name (without underscore prefix)
+     *
+     * @return mixed  Property value, or null if not set
+     */
     public function getProperty($property)
     {
         $prop = '_' . $property;
@@ -577,7 +604,15 @@ class BaseVariable implements Variable
     }
 
     /**
-     * Not part of the interface, implementation detail
+     * Magic getter for accessing internal properties.
+     *
+     * Provides property access using underscore-prefixed naming convention.
+     * Special handling for deprecated 'type' property which triggers a
+     * deprecation warning.
+     *
+     * @param string $property  Property name
+     *
+     * @return mixed  Property value, or $this for deprecated 'type' property
      */
     public function __get($property)
     {
@@ -590,6 +625,17 @@ class BaseVariable implements Variable
         return $this->getProperty($property);
     }
 
+    /**
+     * Sets internal property value by name.
+     *
+     * Sets internal properties using underscore-prefixed naming convention
+     * (e.g., 'size' sets $this->_size).
+     *
+     * @param string $property  Property name (without underscore prefix)
+     * @param mixed $value      Value to set
+     *
+     * @return void
+     */
     public function setProperty($property, $value)
     {
         $prop = '_' . $property;
@@ -597,7 +643,14 @@ class BaseVariable implements Variable
     }
 
     /**
-     * Not part of the interface, implementation detail
+     * Magic setter for internal properties.
+     *
+     * Delegates to setProperty() for underscore-prefixed property access.
+     *
+     * @param string $property  Property name
+     * @param mixed $value      Value to set
+     *
+     * @return void
      */
     public function __set($property, $value)
     {
@@ -609,6 +662,17 @@ class BaseVariable implements Variable
      */
     public function init(...$params) {}
 
+    /**
+     * Hook called on form submission.
+     *
+     * Override this method in subclasses to perform actions when the form
+     * containing this variable is submitted. This is called after validation
+     * but before data processing.
+     *
+     * @param Horde_Variables $vars  Submitted form variables
+     *
+     * @return void
+     */
     public function onSubmit($vars) {}
 
     /**

--- a/src/V3/BooleanVariable.php
+++ b/src/V3/BooleanVariable.php
@@ -10,6 +10,17 @@ use Horde_Form_Translation;
  */
 class BooleanVariable extends BaseVariable
 {
+    /**
+     * Validates boolean field value.
+     *
+     * Boolean fields always validate successfully as they can only be
+     * checked or unchecked (on or off). No validation errors are possible.
+     *
+     * @param Horde_Variables $vars  Form variables
+     * @param mixed $value           Field value to validate
+     *
+     * @return bool  Always returns true
+     */
     public function isValid(Horde_Variables $vars, $value): bool
     {
         return true;

--- a/src/V3/BooleanVariable.php
+++ b/src/V3/BooleanVariable.php
@@ -20,6 +20,8 @@ class BooleanVariable extends BaseVariable
      * @param mixed $value           Field value to validate
      *
      * @return bool  Always returns true
+      *
+      * @api
      */
     public function isValid(Horde_Variables $vars, $value): bool
     {
@@ -34,6 +36,8 @@ class BooleanVariable extends BaseVariable
 
     /**
      * Return info about field type.
+      *
+      * @api
      */
     public function about(): array
     {

--- a/src/V3/CaptchaVariable.php
+++ b/src/V3/CaptchaVariable.php
@@ -14,6 +14,8 @@ class CaptchaVariable extends FigletVariable
 {
     /**
      * Return info about field type.
+      *
+      * @api
      */
     public function about(): array
     {

--- a/src/V3/CategoryVariable.php
+++ b/src/V3/CategoryVariable.php
@@ -39,6 +39,8 @@ class CategoryVariable extends BaseVariable
 
     /**
      * Return info about field type.
+      *
+      * @api
      */
     public function about(): array
     {

--- a/src/V3/CellphoneVariable.php
+++ b/src/V3/CellphoneVariable.php
@@ -13,6 +13,8 @@ class CellphoneVariable extends PhoneVariable
 {
     /**
      * Return info about field type.
+      *
+      * @api
      */
     public function about(): array
     {

--- a/src/V3/ColorpickerVariable.php
+++ b/src/V3/ColorpickerVariable.php
@@ -24,6 +24,8 @@ class ColorpickerVariable extends BaseVariable
 
     /**
      * Return info about field type.
+      *
+      * @api
      */
     public function about(): array
     {

--- a/src/V3/ConditionalenableAction.php
+++ b/src/V3/ConditionalenableAction.php
@@ -64,6 +64,8 @@ class ConditionalenableAction extends BaseAction
      * @param mixed $renderer  The form renderer
      * @param string $varname  Variable name this action applies to
      * @return string  JavaScript code
+      *
+      * @api
      */
     public function getActionScript(\Horde\Form\Form $form, $renderer, string $varname): string
     {

--- a/src/V3/ConditionalsetvalueAction.php
+++ b/src/V3/ConditionalsetvalueAction.php
@@ -71,6 +71,8 @@ class ConditionalsetvalueAction extends BaseAction
      * @param mixed $renderer  The form renderer
      * @param string $varname  Variable name this action applies to
      * @return string  JavaScript code
+      *
+      * @api
      */
     public function getActionScript(\Horde\Form\Form $form, $renderer, string $varname): string
     {
@@ -89,6 +91,8 @@ class ConditionalsetvalueAction extends BaseAction
      * @param \Horde_Variables $vars  The variables object
      * @param mixed $sourceVal  The source value
      * @param bool $arrayVal  Whether dealing with array values
+      *
+      * @api
      */
     public function setValues(\Horde_Variables $vars, $sourceVal, bool $arrayVal = false): void
     {
@@ -120,6 +124,8 @@ class ConditionalsetvalueAction extends BaseAction
      * Print JavaScript code for this action.
      *
      * @return string  JavaScript code
+      *
+      * @api
      */
     public function printJavaScript(): string
     {
@@ -181,6 +187,8 @@ JS;
      * @param mixed $renderer  The renderer
      * @param string $varname  Variable name
      * @return string  Field ID
+      *
+      * @internal
      */
     protected function getFieldId($renderer, string $varname): string
     {

--- a/src/V3/CountedtextVariable.php
+++ b/src/V3/CountedtextVariable.php
@@ -27,6 +27,8 @@ class CountedtextVariable extends LongtextVariable
      *                      - $params[0]: int $rows - Number of rows (default: 8, from parent)
      *                      - $params[1]: int $cols - Number of columns (default: 80, from parent)
      *                      - $params[2]: int $chars - Maximum number of characters (default: 1000)
+      *
+      * @api
      */
     public function init(...$params)
     {
@@ -56,6 +58,8 @@ class CountedtextVariable extends LongtextVariable
 
     /**
      * Return info about field type.
+      *
+      * @api
      */
     public function about(): array
     {

--- a/src/V3/CountryVariable.php
+++ b/src/V3/CountryVariable.php
@@ -18,6 +18,8 @@ class CountryVariable extends EnumVariable
      *
      * @param array $params Variable arguments:
      *                      - $params[0]: string|bool|null $prompt - Prompt text for selection
+      *
+      * @api
      */
     public function init(...$params)
     {
@@ -28,6 +30,8 @@ class CountryVariable extends EnumVariable
 
     /**
      * Return info about field type.
+      *
+      * @api
      */
     public function about(): array
     {

--- a/src/V3/CreditcardVariable.php
+++ b/src/V3/CreditcardVariable.php
@@ -99,6 +99,8 @@ class CreditcardVariable extends BaseVariable
 
     /**
      * Return info about field type.
+      *
+      * @api
      */
     public function about(): array
     {

--- a/src/V3/DateVariable.php
+++ b/src/V3/DateVariable.php
@@ -20,6 +20,8 @@ class DateVariable extends BaseVariable
      *
      * @param array $params Variable arguments:
      *                      - $params[0]: string $format - The date format string (default: '%a %d %B')
+      *
+      * @api
      */
     public function init(...$params)
     {
@@ -93,6 +95,8 @@ class DateVariable extends BaseVariable
 
     /**
      * Return info about field type.
+      *
+      * @api
      */
     public function about(): array
     {

--- a/src/V3/DatetimeVariable.php
+++ b/src/V3/DatetimeVariable.php
@@ -29,6 +29,8 @@ class DatetimeVariable extends BaseVariable
      *                      - $params[3]: string|null $format_in - The format to use when sending the date for storage. Defaults to Unix epoch. Similar to the strftime() function. (default: null)
      *                      - $params[4]: string $format_out - The format to use when displaying the date. Similar to the strftime() function. (default: '%x')
      *                      - $params[5]: bool $show_seconds - Include a form input for seconds (default: false)
+      *
+      * @api
      */
     public function init(...$params)
     {
@@ -160,6 +162,8 @@ class DatetimeVariable extends BaseVariable
 
     /**
      * Return info about field type.
+      *
+      * @api
      */
     public function about(): array
     {

--- a/src/V3/DblookupVariable.php
+++ b/src/V3/DblookupVariable.php
@@ -20,6 +20,8 @@ class DblookupVariable extends EnumVariable
      *                      - $params[0]: Horde_Db_Adapter $db - Database adapter instance
      *                      - $params[1]: string $sql - SQL statement for value lookups
      *                      - $params[2]: string|null $prompt - Prompt text (optional)
+      *
+      * @api
      */
     public function init(...$params)
     {
@@ -39,6 +41,8 @@ class DblookupVariable extends EnumVariable
 
     /**
      * Return info about field type.
+      *
+      * @api
      */
     public function about(): array
     {

--- a/src/V3/DescriptionVariable.php
+++ b/src/V3/DescriptionVariable.php
@@ -16,6 +16,8 @@ class DescriptionVariable extends BaseVariable
 
     /**
      * Return info about field type.
+      *
+      * @api
      */
     public function about(): array
     {

--- a/src/V3/EmailVariable.php
+++ b/src/V3/EmailVariable.php
@@ -76,6 +76,8 @@ class EmailVariable extends BaseVariable
      *                      - $params[3]: string|null $link_name - The name to use when linking to the compose page (default: null)
      *                      - $params[4]: string $delimiters - Character to split multiple addresses with (default: ',')
      *                      - $params[5]: int|null $size - The size of the input field (default: null)
+      *
+      * @api
      */
     public function init(...$params)
     {
@@ -88,6 +90,8 @@ class EmailVariable extends BaseVariable
     }
 
     /**
+      *
+      * @api
      */
     public function isValid(Horde_Variables $vars, $value): bool
     {
@@ -132,6 +136,8 @@ class EmailVariable extends BaseVariable
      * @param string $string  The RFC 822 formatted email address string
      *
      * @return array  Array of individual email addresses (strings)
+      *
+      * @api
      */
     public function splitEmailAddresses($string)
     {
@@ -205,6 +211,8 @@ class EmailVariable extends BaseVariable
      * @param string $email  An individual email address to validate
      *
      * @return bool  True if email is valid, false otherwise
+      *
+      * @api
      */
     public function validateEmailAddress($email)
     {
@@ -225,6 +233,8 @@ class EmailVariable extends BaseVariable
      * @param string $email  An individual email address to validate
      *
      * @return bool  True if SMTP server accepts the address, false otherwise
+      *
+      * @api
      */
     public function validateEmailAddressSmtp($email)
     {
@@ -304,6 +314,8 @@ class EmailVariable extends BaseVariable
      * @param string $email  Email address to validate
      *
      * @return int  1 if valid RFC 3696 address, 0 otherwise
+      *
+      * @internal
      */
     protected function _isRfc3696ValidEmailAddress($email)
     {
@@ -680,6 +692,8 @@ class EmailVariable extends BaseVariable
      * @param string $replace  Replacement string for matched comments (default: empty string)
      *
      * @return string  Email address with all matching comments removed
+      *
+      * @internal
      */
     protected function _rfc3696StripComments($comment, $email, $replace = '')
     {
@@ -694,6 +708,8 @@ class EmailVariable extends BaseVariable
 
     /**
      * Return info about field type.
+      *
+      * @api
      */
     public function about(): array
     {

--- a/src/V3/EmailVariable.php
+++ b/src/V3/EmailVariable.php
@@ -123,13 +123,15 @@ class EmailVariable extends BaseVariable
     }
 
     /**
-     * Explodes an RFC 2822 string, ignoring a delimiter if preceded
-     * by a "\" character, or if the delimiter is inside single or
-     * double quotes.
+     * Splits RFC 2822 formatted email address string into individual addresses.
      *
-     * @param string $string     The RFC 822 string.
+     * Parses email address lists, handling quoted strings, escape characters,
+     * and group syntax (name:addr1,addr2;). Ignores delimiters inside quotes
+     * or preceded by backslash.
      *
-     * @return array  The exploded string in an array.
+     * @param string $string  The RFC 822 formatted email address string
+     *
+     * @return array  Array of individual email addresses (strings)
      */
     public function splitEmailAddresses($string)
     {
@@ -195,9 +197,14 @@ class EmailVariable extends BaseVariable
     }
 
     /**
-     * @param string $email An individual email address to validate.
+     * Validates an email address.
      *
-     * @return boolean
+     * Performs RFC 3696 validation on the email address. If SMTP checking
+     * is enabled, also attempts SMTP validation.
+     *
+     * @param string $email  An individual email address to validate
+     *
+     * @return bool  True if email is valid, false otherwise
      */
     public function validateEmailAddress($email)
     {
@@ -209,11 +216,15 @@ class EmailVariable extends BaseVariable
     }
 
     /**
-     * Attempt partial delivery of mail to an address to validate it.
+     * Validates email address via SMTP connection.
      *
-     * @param string $email An individual email address to validate.
+     * Attempts partial mail delivery to validate the email address exists.
+     * Connects to the mail server via SMTP and checks if RCPT TO command
+     * succeeds. Uses MX records if available, falls back to domain A record.
      *
-     * @return boolean
+     * @param string $email  An individual email address to validate
+     *
+     * @return bool  True if SMTP server accepts the address, false otherwise
      */
     public function validateEmailAddressSmtp($email)
     {
@@ -270,13 +281,29 @@ class EmailVariable extends BaseVariable
     }
 
     /**
-     * RFC3696 Email Parser
+     * Validates email address according to RFC 3696 specification.
      *
+     * Performs comprehensive RFC 3696 validation including:
+     * - Local part and domain length limits (64 and 255 chars)
+     * - Address format validation (dot-atom, quoted-string, domain-literal)
+     * - Domain literal validation (IPv4 and IPv6 addresses)
+     * - Label validation (length, hyphens, numeric TLD checks)
+     * - Comment stripping and nested comment handling
+     *
+     * Implementation uses complex regex patterns built from RFC grammar rules
+     * to validate all address components. Handles obsolete syntax from RFC 2822
+     * and domain literals from RFC 2821.
+     *
+     * RFC3696 Email Parser
      * By Cal Henderson <cal@iamcal.com>
      *
      * This code is dual licensed:
      * CC Attribution-ShareAlike 2.5 - http://creativecommons.org/licenses/by-sa/2.5/
      * GPLv3 - http://www.gnu.org/copyleft/gpl.html
+     *
+     * @param string $email  Email address to validate
+     *
+     * @return int  1 if valid RFC 3696 address, 0 otherwise
      */
     protected function _isRfc3696ValidEmailAddress($email)
     {
@@ -629,8 +656,17 @@ class EmailVariable extends BaseVariable
     }
 
     /**
-     * RFC3696 Email Parser
+     * Strips RFC 2822 comments from email address string.
      *
+     * Recursively removes comments matching the provided regex pattern until
+     * no more matches are found. Comments in RFC 2822 format are enclosed in
+     * parentheses and can be nested. This method handles nested comments by
+     * repeatedly applying the regex replacement until the string stabilizes.
+     *
+     * Used during RFC 3696 email validation to remove comments from the
+     * local part and domain before performing length and format checks.
+     *
+     * RFC3696 Email Parser
      * By Cal Henderson <cal@iamcal.com>
      *
      * This code is dual licensed:
@@ -638,6 +674,12 @@ class EmailVariable extends BaseVariable
      * GPLv3 - http://www.gnu.org/copyleft/gpl.html
      *
      * $Revision: 5039 $
+     *
+     * @param string $comment  Regex pattern matching RFC 2822 comment syntax
+     * @param string $email    Email address string to process
+     * @param string $replace  Replacement string for matched comments (default: empty string)
+     *
+     * @return string  Email address with all matching comments removed
      */
     protected function _rfc3696StripComments($comment, $email, $replace = '')
     {

--- a/src/V3/EmailconfirmVariable.php
+++ b/src/V3/EmailconfirmVariable.php
@@ -34,6 +34,8 @@ class EmailconfirmVariable extends BaseVariable
 
     /**
      * Return info about field type.
+      *
+      * @api
      */
     public function about(): array
     {

--- a/src/V3/EnumVariable.php
+++ b/src/V3/EnumVariable.php
@@ -22,6 +22,8 @@ class EnumVariable extends BaseVariable
      * @param array $params Variable arguments:
      *                      - $params[0]: array $values - A hash map where the key is the internal 'value' to process and the value is the caption presented to the user
      *                      - $params[1]: string|bool $prompt - A null value text to prompt user selecting a value. Use a default if boolean true, else use the supplied string. No prompt on false.
+      *
+      * @api
      */
     public function init(...$params)
     {
@@ -64,6 +66,8 @@ class EnumVariable extends BaseVariable
 
     /**
      * Return info about field type.
+      *
+      * @api
      */
     public function about(): array
     {

--- a/src/V3/FigletVariable.php
+++ b/src/V3/FigletVariable.php
@@ -22,6 +22,8 @@ class FigletVariable extends BaseVariable
      * @param array $params Variable arguments:
      *                      - $params[0]: string $text - The CAPTCHA text
      *                      - $params[1]: string $font - The Figlet font to use
+      *
+      * @api
      */
     public function init(...$params)
     {
@@ -54,6 +56,8 @@ class FigletVariable extends BaseVariable
 
     /**
      * Return info about field type.
+      *
+      * @api
      */
     public function about(): array
     {

--- a/src/V3/FileVariable.php
+++ b/src/V3/FileVariable.php
@@ -11,6 +11,18 @@ use Horde_Browser_Exception;
  */
 class FileVariable extends BaseVariable
 {
+    /**
+     * Validates file upload field.
+     *
+     * Checks if a file was successfully uploaded using the browser's upload
+     * detection. Required fields must have a file uploaded. Optional fields
+     * pass validation even without a file.
+     *
+     * @param Horde_Variables $vars  Form variables
+     * @param mixed $value           Field value (not used; checks $_FILES directly)
+     *
+     * @return bool  True if valid, false with error message set if required file missing
+     */
     public function isValid(Horde_Variables $vars, $value): bool
     {
         if ($this->isRequired()) {

--- a/src/V3/FileVariable.php
+++ b/src/V3/FileVariable.php
@@ -22,6 +22,8 @@ class FileVariable extends BaseVariable
      * @param mixed $value           Field value (not used; checks $_FILES directly)
      *
      * @return bool  True if valid, false with error message set if required file missing
+      *
+      * @api
      */
     public function isValid(Horde_Variables $vars, $value): bool
     {
@@ -58,6 +60,8 @@ class FileVariable extends BaseVariable
 
     /**
      * Return info about field type.
+      *
+      * @api
      */
     public function about(): array
     {

--- a/src/V3/Form.php
+++ b/src/V3/Form.php
@@ -1,6 +1,30 @@
 <?php
+/**
+ * Copyright 2001-2026 Horde LLC (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (LGPL). If you
+ * did not receive this file, see http://www.horde.org/licenses/lgpl21.
+ *
+ * @category Horde
+ * @license  http://www.horde.org/licenses/lgpl21 LGPL
+ * @package  Form
+ */
+
 namespace Horde\Form\V3;
 
-interface Form
+/**
+ * Combined interface for forms.
+ *
+ * Extends both FormMigrationInterface (lib/ compatibility methods)
+ * and FormV3Interface (V3-native methods) to provide the complete
+ * Form API.
+ *
+ * Implementations of this interface support both migrated code from lib/
+ * and new V3-specific functionality.
+ *
+ * @category Horde
+ * @package  Form
+ */
+interface Form extends FormMigrationInterface, FormV3Interface
 {
 }

--- a/src/V3/FormMigrationInterface.php
+++ b/src/V3/FormMigrationInterface.php
@@ -1,0 +1,337 @@
+<?php
+/**
+ * Copyright 2001-2026 Horde LLC (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (LGPL). If you
+ * did not receive this file, see http://www.horde.org/licenses/lgpl21.
+ *
+ * @category Horde
+ * @license  http://www.horde.org/licenses/lgpl21 LGPL
+ * @package  Form
+ */
+
+namespace Horde\Form\V3;
+
+use Horde_Variables;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * Migration interface for Form methods that existed in lib/ (Horde_Form).
+ *
+ * These methods provide backward compatibility with the lib/ implementation.
+ * Code migrating from lib/ to V3 can rely on these methods having similar
+ * signatures and behavior.
+ *
+ * @category Horde
+ * @package  Form
+ */
+interface FormMigrationInterface
+{
+    /**
+     * Returns the form variables as an array.
+     *
+     * @return array  Form variables
+     */
+    public function getVars(): array;
+
+    /**
+     * Sets form variables.
+     *
+     * @param Horde_Variables|ServerRequestInterface|array $vars  Variables to set
+     */
+    public function setVars(Horde_Variables|ServerRequestInterface|array $vars): void;
+
+    /**
+     * Gets a single variable value.
+     *
+     * @param string $name     Variable name
+     * @param mixed $default   Default value if not set
+     *
+     * @return mixed  Variable value
+     */
+    public function getVar(string $name, mixed $default = null): mixed;
+
+    /**
+     * Sets a single variable value.
+     *
+     * @param string $name   Variable name
+     * @param mixed $value   Variable value
+     */
+    public function setVar(string $name, mixed $value): void;
+
+    /**
+     * Returns the form title.
+     *
+     * @return string  Form title
+     */
+    public function getTitle(): string;
+
+    /**
+     * Sets the form title.
+     *
+     * @param string $title  Form title
+     */
+    public function setTitle(string $title): void;
+
+    /**
+     * Returns the extra form content.
+     *
+     * @return string  Extra content
+     */
+    public function getExtra(): string;
+
+    /**
+     * Sets extra form content.
+     *
+     * @param string $extra  Extra content
+     */
+    public function setExtra(string $extra): void;
+
+    /**
+     * Returns the form name.
+     *
+     * @return string  Form name
+     */
+    public function getName(): string;
+
+    /**
+     * Gets or sets token usage.
+     *
+     * @param bool|null $token  Set token usage, or null to get current state
+     *
+     * @return bool  Token usage state
+     */
+    public function useToken(?bool $token = null): bool;
+
+    /**
+     * Sets the currently open form section.
+     *
+     * @param string $section      Section name
+     * @param string $desc         Section description
+     * @param string $image        Section image path
+     * @param bool $expanded       Whether section is expanded
+     */
+    public function setSection(
+        string $section,
+        string $desc = '',
+        string $image = '',
+        bool $expanded = true
+    ): void;
+
+    /**
+     * Gets section description.
+     *
+     * @param string|int $section  Section identifier
+     *
+     * @return string  Section description
+     */
+    public function getSectionDesc(string|int $section): string;
+
+    /**
+     * Gets section image path.
+     *
+     * @param string|int $section  Section identifier
+     *
+     * @return string  Section image path
+     */
+    public function getSectionImage(string|int $section): string;
+
+    /**
+     * Sets the open section.
+     *
+     * @param string|int $section  Section identifier
+     */
+    public function setOpenSection(string|int $section): void;
+
+    /**
+     * Gets the currently open section.
+     *
+     * @return string|int|null  Open section identifier
+     */
+    public function getOpenSection(): string|int|null;
+
+    /**
+     * Gets section expanded state.
+     *
+     * @param string|int $section  Section identifier
+     * @param bool $boolean        Return as boolean vs string
+     *
+     * @return bool|string  Expanded state
+     */
+    public function getSectionExpandedState(string|int $section, bool $boolean = false): bool|string;
+
+    /**
+     * Adds a variable to the form.
+     *
+     * @param string $humanName         Human-readable name
+     * @param string $varName           Internal variable name
+     * @param string|Variable $type     Variable type or instance
+     * @param bool $required            Whether required
+     * @param bool $readonly            Whether readonly
+     * @param string|null $description  Long description
+     * @param mixed $params             Type-specific parameters
+     *
+     * @return Variable  The created variable
+     */
+    public function addVariable(
+        string $humanName,
+        string $varName,
+        string|Variable $type,
+        bool $required,
+        bool $readonly = false,
+        ?string $description = null,
+        mixed $params = []
+    ): Variable;
+
+    /**
+     * Inserts a variable before another variable.
+     *
+     * @param string $before            Variable to insert before
+     * @param string $humanName         Human-readable name
+     * @param string $varName           Internal variable name
+     * @param string|Variable $type     Variable type or instance
+     * @param bool $required            Whether required
+     * @param bool $readonly            Whether readonly
+     * @param string|null $description  Long description
+     * @param mixed $params             Type-specific parameters
+     *
+     * @return Variable  The created variable
+     */
+    public function insertVariableBefore(
+        string $before,
+        string $humanName,
+        string $varName,
+        string|Variable $type,
+        bool $required,
+        bool $readonly = false,
+        ?string $description = null,
+        mixed $params = []
+    ): Variable;
+
+    /**
+     * Removes a variable from the form.
+     *
+     * @param Variable|string $var  Variable instance or name
+     *
+     * @return bool  True if removed, false if not found
+     */
+    public function removeVariable(Variable|string $var): bool;
+
+    /**
+     * Adds a hidden variable.
+     *
+     * @param string $humanName         Human-readable name
+     * @param string $varName           Internal variable name
+     * @param string|Variable $type     Variable type or instance
+     * @param bool $required            Whether required
+     * @param bool $readonly            Whether readonly
+     * @param string|null $description  Long description
+     * @param mixed $params             Type-specific parameters
+     *
+     * @return Variable  The created variable
+     */
+    public function addHidden(
+        string $humanName,
+        string $varName,
+        string|Variable $type,
+        bool $required,
+        bool $readonly = false,
+        ?string $description = null,
+        mixed $params = []
+    ): Variable;
+
+    /**
+     * Gets form variables.
+     *
+     * @param bool $flat          Return flat array vs nested by section
+     * @param bool $withHidden    Include hidden variables
+     *
+     * @return array  Form variables
+     */
+    public function getVariables(bool $flat = true, bool $withHidden = false): array;
+
+    /**
+     * Sets form buttons.
+     *
+     * @param array|string|bool $submit  Submit button configuration
+     * @param string|bool $reset         Reset button configuration
+     */
+    public function setButtons(array|string|bool $submit, string|bool $reset = false): void;
+
+    /**
+     * Appends buttons to existing buttons.
+     *
+     * @param array|string $submit  Submit button configuration
+     */
+    public function appendButtons(array|string $submit): void;
+
+    /**
+     * Validates the form.
+     *
+     * @param Horde_Variables|array|null $vars  Variables to validate
+     *
+     * @return bool  True if valid
+     */
+    public function validate($vars = null): bool;
+
+    /**
+     * Returns whether form is valid.
+     *
+     * @return bool  True if valid
+     */
+    public function isValid(): bool;
+
+    /**
+     * Gets all validation errors.
+     *
+     * @return array  Errors indexed by variable name
+     */
+    public function getErrors(): array;
+
+    /**
+     * Gets error for specific variable.
+     *
+     * @param string $varName  Variable name
+     *
+     * @return string|null  Error message or null
+     */
+    public function getError(string $varName): ?string;
+
+    /**
+     * Sets an error for a variable.
+     *
+     * @param string $varName   Variable name
+     * @param string $message   Error message
+     */
+    public function setError(string $varName, string $message): void;
+
+    /**
+     * Clears errors.
+     *
+     * @param string|null $varName  Variable name, or null for all
+     */
+    public function clearError(?string $varName = null): void;
+
+    /**
+     * Extracts form data.
+     *
+     * @param Horde_Variables|array|null $vars  Variables to extract from
+     *
+     * @return array  Extracted form data
+     */
+    public function getInfo($vars = null): array;
+
+    /**
+     * Returns whether form was submitted.
+     *
+     * @return bool  True if submitted
+     */
+    public function isSubmitted(): bool;
+
+    /**
+     * Gets form encoding type.
+     *
+     * @return string|null  Encoding type or null
+     */
+    public function getEnctype(): ?string;
+}

--- a/src/V3/FormV3Interface.php
+++ b/src/V3/FormV3Interface.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Copyright 2001-2026 Horde LLC (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (LGPL). If you
+ * did not receive this file, see http://www.horde.org/licenses/lgpl21.
+ *
+ * @category Horde
+ * @license  http://www.horde.org/licenses/lgpl21 LGPL
+ * @package  Form
+ */
+
+namespace Horde\Form\V3;
+
+/**
+ * V3-native interface for Form methods introduced in the V3 implementation.
+ *
+ * These methods are new to V3 and provide modernized functionality
+ * not present in lib/ (Horde_Form).
+ *
+ * Note: Most Form functionality is migration-based. V3 improvements are
+ * primarily internal (PSR-7 support, type hints, private helper methods).
+ * This interface is included for completeness but currently empty as all
+ * public methods existed in lib/.
+ *
+ * @category Horde
+ * @package  Form
+ */
+interface FormV3Interface
+{
+    // Currently no V3-specific public methods.
+    // Internal improvements include:
+    // - normalizeVars() - private method for PSR-7/array/Horde_Variables normalization
+    // - getInfoFromVariables() - private extraction method
+    // - createVariable() - private factory method
+    // - Enhanced type hints on all methods (PHP 8+ features)
+}

--- a/src/V3/HeaderVariable.php
+++ b/src/V3/HeaderVariable.php
@@ -16,6 +16,8 @@ class HeaderVariable extends BaseVariable
 
     /**
      * Return info about field type.
+      *
+      * @api
      */
     public function about(): array
     {

--- a/src/V3/HourminutesecondVariable.php
+++ b/src/V3/HourminutesecondVariable.php
@@ -42,6 +42,18 @@ class HourminutesecondVariable extends BaseVariable
         return true;
     }
 
+    /**
+     * Validates time component values.
+     *
+     * Checks that hour (0-23), minute (0-60), and second (0-60) are within
+     * valid ranges and not empty. All three components must be set.
+     *
+     * @param int|string $hour    Hour value (0-23)
+     * @param int|string $minute  Minute value (0-60)
+     * @param int|string $second  Second value (0-60)
+     *
+     * @return bool  True if all components are valid, false otherwise
+     */
     public function checktime($hour, $minute, $second)
     {
         if (!isset($hour) || $hour == '' || ($hour < 0 || $hour > 23)) {
@@ -107,6 +119,16 @@ class HourminutesecondVariable extends BaseVariable
             'second' => $time->sec];
     }
 
+    /**
+     * Checks if time array is empty.
+     *
+     * A time array is considered empty if hour and minute are not set or have
+     * empty string values. If seconds are shown, second must also be empty.
+     *
+     * @param array|mixed $time  Time array with 'hour', 'minute', 'second' keys
+     *
+     * @return bool  True if time array is empty, false otherwise
+     */
     public function emptyTimeArray($time)
     {
         return (is_array($time)

--- a/src/V3/HourminutesecondVariable.php
+++ b/src/V3/HourminutesecondVariable.php
@@ -19,6 +19,8 @@ class HourminutesecondVariable extends BaseVariable
      *
      * @param array $params Variable arguments:
      *                      - $params[0]: bool $show_seconds - Include a form input for seconds (default: false)
+      *
+      * @api
      */
     public function init(...$params)
     {
@@ -53,6 +55,8 @@ class HourminutesecondVariable extends BaseVariable
      * @param int|string $second  Second value (0-60)
      *
      * @return bool  True if all components are valid, false otherwise
+      *
+      * @api
      */
     public function checktime($hour, $minute, $second)
     {
@@ -80,6 +84,8 @@ class HourminutesecondVariable extends BaseVariable
      *                         UNIX epoch).
      *
      * @return Horde_Date  The time object.
+      *
+      * @api
      */
     public function getTimeOb($time_in)
     {
@@ -101,6 +107,8 @@ class HourminutesecondVariable extends BaseVariable
      *                         UNIX epoch).
      *
      * @return array  Array with three elements - hour, minute and seconds.
+      *
+      * @api
      */
     public function getTimeParts($time_in)
     {
@@ -128,6 +136,8 @@ class HourminutesecondVariable extends BaseVariable
      * @param array|mixed $time  Time array with 'hour', 'minute', 'second' keys
      *
      * @return bool  True if time array is empty, false otherwise
+      *
+      * @api
      */
     public function emptyTimeArray($time)
     {
@@ -139,6 +149,8 @@ class HourminutesecondVariable extends BaseVariable
 
     /**
      * Return info about field type.
+      *
+      * @api
      */
     public function about(): array
     {

--- a/src/V3/HtmlRenderer.php
+++ b/src/V3/HtmlRenderer.php
@@ -68,6 +68,8 @@ class HtmlRenderer extends BaseRenderer
      * @param ErrorRenderer|null $errorRenderer  Error renderer
      * @param AssetManager|null $assetManager  Asset manager
      * @param array<string, mixed> $config  Configuration options
+      *
+      * @api
      */
     public function __construct(
         ?ControlRenderer $controlRenderer = null,
@@ -93,6 +95,8 @@ class HtmlRenderer extends BaseRenderer
 
     /**
      * Create default control renderer.
+      *
+      * @internal
      */
     protected function createDefaultControlRenderer(): ControlRenderer
     {
@@ -107,6 +111,8 @@ class HtmlRenderer extends BaseRenderer
 
     /**
      * Create default layout strategy.
+      *
+      * @internal
      */
     protected function createDefaultLayoutStrategy(): LayoutStrategy
     {
@@ -115,6 +121,8 @@ class HtmlRenderer extends BaseRenderer
 
     /**
      * Create default error renderer.
+      *
+      * @internal
      */
     protected function createDefaultErrorRenderer(): ErrorRenderer
     {
@@ -123,6 +131,8 @@ class HtmlRenderer extends BaseRenderer
 
     /**
      * Create default asset manager.
+      *
+      * @internal
      */
     protected function createDefaultAssetManager(): AssetManager
     {
@@ -131,6 +141,8 @@ class HtmlRenderer extends BaseRenderer
 
     /**
      * Render form opening tag.
+      *
+      * @api
      */
     public function renderOpen(\Horde\Form\Form $form, string $action, string $method): string
     {
@@ -153,6 +165,8 @@ class HtmlRenderer extends BaseRenderer
 
     /**
      * Render form closing tag.
+      *
+      * @api
      */
     public function renderClose(): string
     {
@@ -161,6 +175,8 @@ class HtmlRenderer extends BaseRenderer
 
     /**
      * Render form header.
+      *
+      * @api
      */
     public function renderHeader(\Horde\Form\Form $form): string
     {
@@ -189,6 +205,8 @@ class HtmlRenderer extends BaseRenderer
 
     /**
      * Render form buttons.
+      *
+      * @api
      */
     public function renderButtons(\Horde\Form\Form $form): string
     {
@@ -211,6 +229,8 @@ class HtmlRenderer extends BaseRenderer
      * Set rendering mode.
      *
      * @param string $mode  Mode: active, inactive, print
+      *
+      * @api
      */
     public function setMode(string $mode): void
     {
@@ -219,6 +239,8 @@ class HtmlRenderer extends BaseRenderer
 
     /**
      * Get rendering mode.
+      *
+      * @api
      */
     public function getMode(): string
     {
@@ -229,6 +251,8 @@ class HtmlRenderer extends BaseRenderer
      * Set control rendering mode.
      *
      * @param string $mode  Control mode: modern, legacy, fallback
+      *
+      * @api
      */
     public function setControlMode(string $mode): void
     {
@@ -244,6 +268,8 @@ class HtmlRenderer extends BaseRenderer
      * Get control rendering mode.
      *
      * @return string  Control mode
+      *
+      * @api
      */
     public function getControlMode(): string
     {

--- a/src/V3/HtmlVariable.php
+++ b/src/V3/HtmlVariable.php
@@ -16,6 +16,8 @@ class HtmlVariable extends BaseVariable
 
     /**
      * Return info about field type.
+      *
+      * @api
      */
     public function about(): array
     {

--- a/src/V3/ImageVariable.php
+++ b/src/V3/ImageVariable.php
@@ -67,6 +67,8 @@ class ImageVariable extends BaseVariable
      *                      - $params[0]: bool $show_upload - Show the upload button (default: true)
      *                      - $params[1]: bool $show_keeporig - Show the option to upload also original non-modified image (default: false)
      *                      - $params[2]: int|null $max_filesize - Limit the file size in bytes (default: null)
+      *
+      * @api
      */
     public function init(...$params)
     {
@@ -76,6 +78,8 @@ class ImageVariable extends BaseVariable
     }
 
     /**
+      *
+      * @api
      */
     public function onSubmit($vars)
     {
@@ -106,6 +110,8 @@ class ImageVariable extends BaseVariable
      * @param Horde_Form_Variable $var  The Form field object to check
      * @param Horde_Variables $vars     The form state to check this field for
      * @param array $value              The field value array - should contain a key ['hash'] which holds the key for the image on temp storage
+      *
+      * @api
      */
     public function isValid(Horde_Variables $vars, $value): bool
     {
@@ -348,6 +354,8 @@ class ImageVariable extends BaseVariable
      *
      * @param Horde_Variables $vars     The form state to check this field for
      * @return array  The current image hash.
+      *
+      * @api
      */
     public function getImage($vars)
     {
@@ -376,6 +384,8 @@ class ImageVariable extends BaseVariable
      *   $image['load']['data'] - the raw image data.
      *
      * @param array $image  The image array.
+      *
+      * @api
      */
     public function loadImageData($image)
     {
@@ -408,6 +418,8 @@ class ImageVariable extends BaseVariable
 
     /**
      * Return info about field type.
+      *
+      * @api
      */
     public function about(): array
     {

--- a/src/V3/IntVariable.php
+++ b/src/V3/IntVariable.php
@@ -9,6 +9,17 @@ use Horde_Form_Translation;
  */
 class IntVariable extends BaseVariable
 {
+    /**
+     * Validates integer field value.
+     *
+     * Checks that the value contains only digits (0-9). Required fields
+     * must have a non-empty value. Empty optional fields pass validation.
+     *
+     * @param Horde_Variables $vars  Form variables
+     * @param mixed $value           Field value to validate
+     *
+     * @return bool  True if valid, false with error message set if invalid
+     */
     public function isValid(Horde_Variables $vars, $value): bool
     {
         if ($this->isRequired() && empty($value) && ((string) (int) $value !== $value)) {

--- a/src/V3/IntVariable.php
+++ b/src/V3/IntVariable.php
@@ -19,6 +19,8 @@ class IntVariable extends BaseVariable
      * @param mixed $value           Field value to validate
      *
      * @return bool  True if valid, false with error message set if invalid
+      *
+      * @api
      */
     public function isValid(Horde_Variables $vars, $value): bool
     {
@@ -35,6 +37,8 @@ class IntVariable extends BaseVariable
 
     /**
      * Return info about field type.
+      *
+      * @api
      */
     public function about(): array
     {

--- a/src/V3/IntlistVariable.php
+++ b/src/V3/IntlistVariable.php
@@ -24,6 +24,8 @@ class IntlistVariable extends BaseVariable
 
     /**
      * Return info about field type.
+      *
+      * @api
      */
     public function about(): array
     {

--- a/src/V3/InvalidVariable.php
+++ b/src/V3/InvalidVariable.php
@@ -16,6 +16,8 @@ class InvalidVariable extends BaseVariable
      *
      * @param array $params Variable arguments:
      *                      - $params[0]: string $message - The error message to display (default: '')
+      *
+      * @api
      */
     public function init(...$params)
     {
@@ -29,6 +31,8 @@ class InvalidVariable extends BaseVariable
 
     /**
      * Return info about field type.
+      *
+      * @api
      */
     public function about(): array
     {

--- a/src/V3/Ip6addressVariable.php
+++ b/src/V3/Ip6addressVariable.php
@@ -29,6 +29,8 @@ class Ip6addressVariable extends TextVariable
 
     /**
      * Return info about field type.
+      *
+      * @api
      */
     public function about(): array
     {

--- a/src/V3/IpaddressVariable.php
+++ b/src/V3/IpaddressVariable.php
@@ -41,6 +41,8 @@ class IpaddressVariable extends TextVariable
 
     /**
      * Return info about field type.
+      *
+      * @api
      */
     public function about(): array
     {

--- a/src/V3/KeyvalMultienumVariable.php
+++ b/src/V3/KeyvalMultienumVariable.php
@@ -26,6 +26,8 @@ class KeyvalMultienumVariable extends MultienumVariable
 
     /**
      * Return info about field type.
+      *
+      * @api
      */
     public function about(): array
     {

--- a/src/V3/LinkVariable.php
+++ b/src/V3/LinkVariable.php
@@ -24,6 +24,8 @@ class LinkVariable extends BaseVariable
      *
      * @param array $params Variable arguments:
      *                      - $params[0]: array|null $values - List of hashes containing link parameters. Possible keys: 'url', 'text', 'target', 'onclick', 'title', 'accesskey', 'class' (default: null)
+      *
+      * @api
      */
     public function init(...$params)
     {
@@ -37,6 +39,8 @@ class LinkVariable extends BaseVariable
 
     /**
      * Return info about field type.
+      *
+      * @api
      */
     public function about(): array
     {

--- a/src/V3/LongtextVariable.php
+++ b/src/V3/LongtextVariable.php
@@ -27,6 +27,8 @@ class LongtextVariable extends TextVariable
      *                      - $params[0]: int $rows - Number of rows (default: 8)
      *                      - $params[1]: int $cols - Number of columns (default: 80)
      *                      - $params[2]: array $helper - Array of helper options (default: [])
+      *
+      * @api
      */
     public function init(...$params)
     {
@@ -72,6 +74,8 @@ class LongtextVariable extends TextVariable
 
     /**
      * Return info about field type.
+      *
+      * @api
      */
     public function about(): array
     {

--- a/src/V3/MatrixVariable.php
+++ b/src/V3/MatrixVariable.php
@@ -37,6 +37,8 @@ class MatrixVariable extends BaseVariable
      *                      - $params[1]: array $rows - A hash with row IDs as the keys and row labels as the values (default: [])
      *                      - $params[2]: array $matrix - A two dimensional hash with the field values (default: [])
      *                      - $params[3]: bool|array $new_input - If true, a free text field to add a new row is displayed on the top, a select box if this parameter is a value (default: false)
+      *
+      * @api
      */
     public function init(...$params)
     {
@@ -86,6 +88,8 @@ class MatrixVariable extends BaseVariable
 
     /**
      * Return info about field type.
+      *
+      * @api
      */
     public function about(): array
     {

--- a/src/V3/MlenumVariable.php
+++ b/src/V3/MlenumVariable.php
@@ -21,6 +21,8 @@ class MlenumVariable extends BaseVariable
      * @param array $params Variable arguments:
      *                      - $params[0]: array $values - Values to select from (passed by reference)
      *                      - $params[1]: bool|string|array|null $prompts - Prompt text. If true, uses default "-- select --" for both levels. If string, uses same prompt for both levels. If array, uses different prompts for each level. (default: null)
+      *
+      * @api
      */
     public function init(...$params)
     {
@@ -78,6 +80,8 @@ class MlenumVariable extends BaseVariable
 
     /**
      * Return info about field type.
+      *
+      * @api
      */
     public function about(): array
     {

--- a/src/V3/MonthdayyearVariable.php
+++ b/src/V3/MonthdayyearVariable.php
@@ -31,6 +31,8 @@ class MonthdayyearVariable extends BaseVariable
      *                      - $params[2]: bool $picker - Do we show the DHTML calendar (default: true)
      *                      - $params[3]: string|null $format_in - The format to use when sending the date for storage. Defaults to Unix epoch. Similar to the strftime() function. (default: null)
      *                      - $params[4]: string $format_out - The format to use when displaying the date. Similar to the strftime() function. (default: '%x')
+      *
+      * @api
      */
     public function init(...$params)
     {
@@ -84,6 +86,8 @@ class MonthdayyearVariable extends BaseVariable
      *
      * @return integer  0 for non-empty, 1 for completely empty or -1 for
      *                  partially empty.
+      *
+      * @api
      */
     public function emptyDateArray($date)
     {
@@ -121,6 +125,8 @@ class MonthdayyearVariable extends BaseVariable
      *                         and UNIX epoch) plus the fourth YYYY-MM-DD.
      *
      * @return array  Array with three elements - year, month and day.
+      *
+      * @api
      */
     public function getDateParts($date_in)
     {
@@ -148,6 +154,8 @@ class MonthdayyearVariable extends BaseVariable
      *                         and UNIX epoch) plus the fourth YYYY-MM-DD.
      *
      * @return Horde_Date  The date object.
+      *
+      * @api
      */
     public function getDateOb($date_in)
     {
@@ -180,6 +188,8 @@ class MonthdayyearVariable extends BaseVariable
      *
      * @return string  The date formatted according to the $format_out
      *                 parameter when setting up the monthdayyear field.
+      *
+      * @api
      */
     public function formatDate($date)
     {
@@ -227,6 +237,8 @@ class MonthdayyearVariable extends BaseVariable
 
     /**
      * Return info about field type.
+      *
+      * @api
      */
     public function about(): array
     {

--- a/src/V3/MonthyearVariable.php
+++ b/src/V3/MonthyearVariable.php
@@ -21,6 +21,8 @@ class MonthyearVariable extends BaseVariable
      * @param array $params Variable arguments:
      *                      - $params[0]: int|null $start_year - The first available year for input (default: 1920)
      *                      - $params[1]: int|null $end_year - The last available year for input (default: current year)
+      *
+      * @api
      */
     public function init(...$params)
     {
@@ -63,6 +65,8 @@ class MonthyearVariable extends BaseVariable
 
     /**
      * Return info about field type.
+      *
+      * @api
      */
     public function about(): array
     {

--- a/src/V3/MultienumVariable.php
+++ b/src/V3/MultienumVariable.php
@@ -21,6 +21,8 @@ class MultienumVariable extends EnumVariable
      * @param array $params Variable arguments:
      *                      - $params[0]: array $values - A hash map where the key is the internal 'value' to process and the value is the caption presented to the user
      *                      - $params[1]: int|null $size - The number of rows the multienum should display before scrolling (optional)
+      *
+      * @api
      */
     public function init(...$params)
     {
@@ -45,6 +47,8 @@ class MultienumVariable extends EnumVariable
      * @param mixed $value           Single value or array of values to validate
      *
      * @return bool  True if all values valid, false with error message if invalid
+      *
+      * @api
      */
     public function isValid(Horde_Variables $vars, $value): bool
     {
@@ -73,6 +77,8 @@ class MultienumVariable extends EnumVariable
 
     /**
      * Return info about field type.
+      *
+      * @api
      */
     public function about(): array
     {

--- a/src/V3/MultienumVariable.php
+++ b/src/V3/MultienumVariable.php
@@ -34,6 +34,18 @@ class MultienumVariable extends EnumVariable
         parent::init($values);
     }
 
+    /**
+     * Validates multiple selection field value.
+     *
+     * Accepts arrays (multiple selections) or single values. Each selected
+     * value must exist in the configured values list. Required fields must
+     * have at least one selection. Recursively validates array values.
+     *
+     * @param Horde_Variables $vars  Form variables
+     * @param mixed $value           Single value or array of values to validate
+     *
+     * @return bool  True if all values valid, false with error message if invalid
+     */
     public function isValid(Horde_Variables $vars, $value): bool
     {
         if (is_array($value)) {

--- a/src/V3/NumberVariable.php
+++ b/src/V3/NumberVariable.php
@@ -19,6 +19,8 @@ class NumberVariable extends BaseVariable
      *
      * @param array $params Variable arguments:
      *                      - $params[0]: int|null $fraction - Maximum number of decimal places allowed (default: null, unlimited)
+      *
+      * @api
      */
     public function init(...$params)
     {
@@ -95,6 +97,8 @@ class NumberVariable extends BaseVariable
 
     /**
      * Return info about field type.
+      *
+      * @api
      */
     public function about(): array
     {

--- a/src/V3/ObrowserVariable.php
+++ b/src/V3/ObrowserVariable.php
@@ -16,6 +16,8 @@ class ObrowserVariable extends BaseVariable
 
     /**
      * Return info about field type.
+      *
+      * @api
      */
     public function about(): array
     {

--- a/src/V3/OctalVariable.php
+++ b/src/V3/OctalVariable.php
@@ -24,6 +24,8 @@ class OctalVariable extends BaseVariable
 
     /**
      * Return info about field type.
+      *
+      * @api
      */
     public function about(): array
     {

--- a/src/V3/PasswordVariable.php
+++ b/src/V3/PasswordVariable.php
@@ -20,6 +20,8 @@ class PasswordVariable extends BaseVariable
 
     /**
      * Return info about field type.
+      *
+      * @api
      */
     public function about(): array
     {

--- a/src/V3/PasswordconfirmVariable.php
+++ b/src/V3/PasswordconfirmVariable.php
@@ -31,6 +31,8 @@ class PasswordconfirmVariable extends BaseVariable
 
     /**
      * Return info about field type.
+      *
+      * @api
      */
     public function about(): array
     {

--- a/src/V3/PgpVariable.php
+++ b/src/V3/PgpVariable.php
@@ -40,6 +40,8 @@ class PgpVariable extends LongtextVariable
      *                      - $params[1]: string|null $temp_dir - A temporary directory
      *                      - $params[2]: int $rows - Number of rows (default: 8, from parent)
      *                      - $params[3]: int $cols - Number of columns (default: 80, from parent)
+      *
+      * @api
      */
     public function init(...$params)
     {
@@ -65,6 +67,8 @@ class PgpVariable extends LongtextVariable
 
     /**
      * Return info about field type.
+      *
+      * @api
      */
     public function about(): array
     {

--- a/src/V3/PhoneVariable.php
+++ b/src/V3/PhoneVariable.php
@@ -23,6 +23,8 @@ class PhoneVariable extends BaseVariable
      *
      * @param array $params Variable arguments:
      *                      - $params[0]: int $size - The size of the input field (default: 15)
+      *
+      * @api
      */
     public function init(...$params)
     {
@@ -49,6 +51,8 @@ class PhoneVariable extends BaseVariable
 
     /**
      * Return info about field type.
+      *
+      * @api
      */
     public function about(): array
     {

--- a/src/V3/RadioVariable.php
+++ b/src/V3/RadioVariable.php
@@ -17,6 +17,8 @@ class RadioVariable extends EnumVariable
 
     /**
      * Return info about field type.
+      *
+      * @api
      */
     public function about(): array
     {

--- a/src/V3/ReloadAction.php
+++ b/src/V3/ReloadAction.php
@@ -54,6 +54,8 @@ class ReloadAction extends BaseAction
      * @param mixed $renderer  The form renderer
      * @param string $varname  Variable name
      * @return string  JavaScript code
+      *
+      * @api
      */
     public function getActionScript(\Horde\Form\Form $form, $renderer, string $varname): string
     {

--- a/src/V3/Renderer.php
+++ b/src/V3/Renderer.php
@@ -56,6 +56,8 @@ interface Renderer
      * @param string $action  Form action URL
      * @param string $method  HTTP method (get/post)
      * @return string  Complete rendered output
+      *
+      * @api
      */
     public function render(Form $form, string $action = '', string $method = 'post'): string;
 
@@ -66,6 +68,8 @@ interface Renderer
      * @param string $action  Form action URL
      * @param string $method  HTTP method
      * @return string  Opening form tag
+      *
+      * @api
      */
     public function renderOpen(Form $form, string $action, string $method): string;
 
@@ -73,6 +77,8 @@ interface Renderer
      * Render form closing tag.
      *
      * @return string  Closing form tag
+      *
+      * @api
      */
     public function renderClose(): string;
 
@@ -81,6 +87,8 @@ interface Renderer
      *
      * @param Form $form  The form to render
      * @return string  Form header HTML
+      *
+      * @api
      */
     public function renderHeader(Form $form): string;
 
@@ -90,6 +98,8 @@ interface Renderer
      * @param Variable $variable  The variable to render
      * @param Form $form  The parent form
      * @return string  Rendered field
+      *
+      * @api
      */
     public function renderVariable(Variable $variable, Form $form): string;
 
@@ -100,6 +110,8 @@ interface Renderer
      * @param array<Variable> $variables  Variables in this section
      * @param Form $form  The parent form
      * @return string  Rendered section
+      *
+      * @api
      */
     public function renderSection(string|int $sectionName, array $variables, Form $form): string;
 
@@ -108,6 +120,8 @@ interface Renderer
      *
      * @param Form $form  The form to render
      * @return string  Form buttons HTML
+      *
+      * @api
      */
     public function renderButtons(Form $form): string;
 
@@ -116,6 +130,8 @@ interface Renderer
      *
      * @param Form $form  The form to render
      * @return string  Errors HTML
+      *
+      * @api
      */
     public function renderErrors(Form $form): string;
 
@@ -124,6 +140,8 @@ interface Renderer
      *
      * @param Form $form  The form to render
      * @return string  Hidden fields HTML
+      *
+      * @api
      */
     public function renderHidden(Form $form): string;
 }

--- a/src/V3/SelectfilesVariable.php
+++ b/src/V3/SelectfilesVariable.php
@@ -50,6 +50,8 @@ class SelectfilesVariable extends BaseVariable
      *                      - $params[1]: string|null $link_text - The text to use in the link (default: "Select Files")
      *                      - $params[2]: string $link_style - The style to use for the link (default: '')
      *                      - $params[3]: bool $icon - Create the link with an icon instead of text (default: false)
+      *
+      * @api
      */
     public function init(...$params)
     {
@@ -81,6 +83,8 @@ class SelectfilesVariable extends BaseVariable
 
     /**
      * Return info about field type.
+      *
+      * @api
      */
     public function about(): array
     {

--- a/src/V3/SetVariable.php
+++ b/src/V3/SetVariable.php
@@ -21,6 +21,8 @@ class SetVariable extends BaseVariable
      * @param array $params Variable arguments:
      *                      - $params[0]: array $values - Values available for selection
      *                      - $params[1]: bool $checkAll - Show "check all" option (default: false)
+      *
+      * @api
      */
     public function init(...$params)
     {
@@ -50,6 +52,8 @@ class SetVariable extends BaseVariable
 
     /**
      * Return info about field type.
+      *
+      * @api
      */
     public function about(): array
     {

--- a/src/V3/SetcursorposAction.php
+++ b/src/V3/SetcursorposAction.php
@@ -65,6 +65,8 @@ class SetcursorposAction extends BaseAction
      * @param mixed $renderer  The form renderer
      * @param string $varname  Variable name this action applies to
      * @return string  JavaScript code
+      *
+      * @api
      */
     public function getActionScript(\Horde\Form\Form $form, $renderer, string $varname): string
     {
@@ -83,6 +85,8 @@ class SetcursorposAction extends BaseAction
      * Print JavaScript code for this action.
      *
      * @return string  JavaScript code
+      *
+      * @api
      */
     public function printJavaScript(): string
     {

--- a/src/V3/SmimeVariable.php
+++ b/src/V3/SmimeVariable.php
@@ -31,6 +31,8 @@ class SmimeVariable extends LongtextVariable
      *                      - $params[0]: string|null $temp_dir - A temporary directory
      *                      - $params[1]: int $rows - Number of rows (default: 8, from parent)
      *                      - $params[2]: int $cols - Number of columns (default: 80, from parent)
+      *
+      * @api
      */
     public function init(...$params)
     {
@@ -54,6 +56,8 @@ class SmimeVariable extends LongtextVariable
 
     /**
      * Return info about field type.
+      *
+      * @api
      */
     public function about(): array
     {

--- a/src/V3/SorterVariable.php
+++ b/src/V3/SorterVariable.php
@@ -26,6 +26,8 @@ class SorterVariable extends BaseVariable
      *                      - $params[0]: array $values - Values available for sorting
      *                      - $params[1]: int $size - Size of the select list (default: 8)
      *                      - $params[2]: string $header - Header text for the select list (default: '')
+      *
+      * @api
      */
     public function init(...$params)
     {
@@ -97,6 +99,8 @@ class SorterVariable extends BaseVariable
 
     /**
      * Return info about field type.
+      *
+      * @api
      */
     public function about(): array
     {

--- a/src/V3/SoundVariable.php
+++ b/src/V3/SoundVariable.php
@@ -18,6 +18,8 @@ class SoundVariable extends BaseVariable
      * Initialize a sound selection field.
      *
      * @param array $params Variable arguments (none used, sounds are loaded from theme)
+      *
+      * @api
      */
     public function init(...$params)
     {
@@ -44,6 +46,8 @@ class SoundVariable extends BaseVariable
 
     /**
      * Return info about field type.
+      *
+      * @api
      */
     public function about(): array
     {

--- a/src/V3/SpacerVariable.php
+++ b/src/V3/SpacerVariable.php
@@ -16,6 +16,8 @@ class SpacerVariable extends BaseVariable
 
     /**
      * Return info about field type.
+      *
+      * @api
      */
     public function about(): array
     {

--- a/src/V3/StringarrayVariable.php
+++ b/src/V3/StringarrayVariable.php
@@ -21,6 +21,8 @@ class StringarrayVariable extends StringlistVariable
 
     /**
      * Return info about field type.
+      *
+      * @api
      */
     public function about(): array
     {

--- a/src/V3/StringlistVariable.php
+++ b/src/V3/StringlistVariable.php
@@ -15,6 +15,8 @@ class StringlistVariable extends TextVariable
 {
     /**
      * Return info about field type.
+      *
+      * @api
      */
     public function about(): array
     {

--- a/src/V3/SubmitAction.php
+++ b/src/V3/SubmitAction.php
@@ -51,6 +51,8 @@ class SubmitAction extends BaseAction
      * @param mixed $renderer  The form renderer
      * @param string $varname  Variable name
      * @return string  JavaScript code
+      *
+      * @api
      */
     public function getActionScript(\Horde\Form\Form $form, $renderer, string $varname): string
     {

--- a/src/V3/SumfieldsAction.php
+++ b/src/V3/SumfieldsAction.php
@@ -55,6 +55,8 @@ class SumfieldsAction extends BaseAction
      * @param mixed $renderer  The form renderer
      * @param string $varname  Variable name (the target sum field)
      * @return string  JavaScript code
+      *
+      * @api
      */
     public function getActionScript(\Horde\Form\Form $form, $renderer, string $varname): string
     {

--- a/src/V3/TablesetVariable.php
+++ b/src/V3/TablesetVariable.php
@@ -21,6 +21,8 @@ class TablesetVariable extends BaseVariable
      * @param array $params Variable arguments:
      *                      - $params[0]: array $values - The values for the table set.
      *                      - $params[1]: array $header - The headers for the table set.
+      *
+      * @api
      */
     public function init(...$params)
     {
@@ -57,6 +59,8 @@ class TablesetVariable extends BaseVariable
 
     /**
      * Return info about field type.
+      *
+      * @api
      */
     public function about(): array
     {

--- a/src/V3/TextVariable.php
+++ b/src/V3/TextVariable.php
@@ -25,6 +25,8 @@ class TextVariable extends BaseVariable
      *                      - $params[0]: string $regex - Any valid PHP PCRE pattern syntax that needs to be matched for the field to be considered valid. If left empty validity will be checked only for required fields whether they are empty or not. If using this regex test it is advisable to enter a description for this field to warn the user what is expected, as the generated error message is quite generic and will not give any indication where the regex failed.
      *                      - $params[1]: int $size - The size of the input field.
      *                      - $params[2]: int|null $maxlength - The max number of characters.
+      *
+      * @api
      */
     public function init(...$params)
     {
@@ -63,6 +65,8 @@ class TextVariable extends BaseVariable
 
     /**
      * Return info about field type.
+      *
+      * @api
      */
     public function about(): array
     {

--- a/src/V3/TimeVariable.php
+++ b/src/V3/TimeVariable.php
@@ -22,6 +22,8 @@ class TimeVariable extends BaseVariable
 
     /**
      * Return info about field type.
+      *
+      * @api
      */
     public function about(): array
     {

--- a/src/V3/UpdatefieldAction.php
+++ b/src/V3/UpdatefieldAction.php
@@ -76,6 +76,8 @@ class UpdatefieldAction extends BaseAction
      * @param mixed $renderer  The form renderer
      * @param string $varname  Variable name this action applies to
      * @return string  JavaScript code
+      *
+      * @api
      */
     public function getActionScript(\Horde\Form\Form $form, $renderer, string $varname): string
     {
@@ -89,6 +91,8 @@ class UpdatefieldAction extends BaseAction
      * @param mixed $sourceVal  The source value
      * @param int|null $index  Array index
      * @param bool $arrayVal  Whether dealing with array values
+      *
+      * @api
      */
     public function setValues(\Horde_Variables $vars, $sourceVal, ?int $index = null, bool $arrayVal = false): void
     {
@@ -99,6 +103,8 @@ class UpdatefieldAction extends BaseAction
      * Print JavaScript code for this action.
      *
      * @return string  JavaScript code
+      *
+      * @api
      */
     public function printJavaScript(): string
     {

--- a/src/V3/Variable.php
+++ b/src/V3/Variable.php
@@ -1,57 +1,31 @@
 <?php
 /**
- * Copyright 2001-2025 Horde LLC (http://www.horde.org/)
+ * Copyright 2001-2026 Horde LLC (http://www.horde.org/)
  *
  * See the enclosed file LICENSE for license information (LGPL). If you
  * did not receive this file, see http://www.horde.org/licenses/lgpl21.
  *
  * @author   Robert E. Coyle <robertecoyle@hotmail.com>
+ * @category Horde
+ * @license  http://www.horde.org/licenses/lgpl21 LGPL
+ * @package  Form
  */
 
 namespace Horde\Form\V3;
-use Horde_Variables;
 
-interface Variable
+/**
+ * Combined interface for form variables.
+ *
+ * Extends both VariableMigrationInterface (lib/ compatibility methods)
+ * and VariableV3Interface (V3-native methods) to provide the complete
+ * Variable API.
+ *
+ * Implementations of this interface support both migrated code from lib/
+ * and new V3-specific functionality.
+ *
+ * @category Horde
+ * @package  Form
+ */
+interface Variable extends VariableMigrationInterface, VariableV3Interface
 {
-    public function getMessage();
-    public function setFormOb($form);
-    public function setDefault($value);
-    public function getDefault();
-    public function setAction($action);
-    public function hasAction();
-    public function hide();
-    public function isHidden();
-    public function disable();
-    public function isDisabled();
-    public function getHumanName();
-    public function getTypeName(): string;
-    public function getVarName();
-//    public function getType();
-//    public function isRequired();
-//    public function isReadonly();
-    public function hasDescription(): bool;
-    public function getDescription();
-    public function isArrayVal();
-    public function isUpload();
-    public function setHelp($help);
-    public function hasHelp();
-    public function getHelp();
-    public function setOption($option, $val);
-    public function getOption($option);
-
-    public function getInfo($vars, ...$args);
-
-    public function wasChanged($vars);
-    public function validate($vars, $message);
-    public function getValue($vars, $index = null);
-    public function invalid(string $message): bool;
-
-    // Former type methods
-    public function getProperty($property);
-    public function setProperty($property, $value);
-    public function init(...$params);
-    public function onSubmit($vars);
-    //public function isValid(Horde_Variables $vars, $value): bool;
-    public function getValues(...$params);
-    public function about(): array;
 }

--- a/src/V3/VariableMigrationInterface.php
+++ b/src/V3/VariableMigrationInterface.php
@@ -1,0 +1,230 @@
+<?php
+/**
+ * Copyright 2001-2026 Horde LLC (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (LGPL). If you
+ * did not receive this file, see http://www.horde.org/licenses/lgpl21.
+ *
+ * @author   Robert E. Coyle <robertecoyle@hotmail.com>
+ * @category Horde
+ * @license  http://www.horde.org/licenses/lgpl21 LGPL
+ * @package  Form
+ */
+
+namespace Horde\Form\V3;
+
+use Horde_Variables;
+
+/**
+ * Migration interface for Variable methods that existed in lib/ (Horde_Form_Variable).
+ *
+ * These methods provide backward compatibility with the lib/ implementation.
+ * Code migrating from lib/ to V3 can rely on these methods having similar
+ * signatures and behavior.
+ *
+ * @category Horde
+ * @package  Form
+ */
+interface VariableMigrationInterface
+{
+    /**
+     * Assign this variable to a form.
+     *
+     * @param \Horde\Form\Form $form  The form instance
+     */
+    public function setFormOb($form);
+
+    /**
+     * Sets a default value for this variable.
+     *
+     * @param mixed $value  A variable value
+     */
+    public function setDefault($value);
+
+    /**
+     * Returns this variable's default value.
+     *
+     * @return mixed  This variable's default value
+     */
+    public function getDefault();
+
+    /**
+     * Assigns an action to this variable.
+     *
+     * @param Action $action  An Action instance
+     */
+    public function setAction($action);
+
+    /**
+     * Returns whether this variable has an attached action.
+     *
+     * @return bool  True if this variable has an attached action
+     */
+    public function hasAction();
+
+    /**
+     * Makes this a hidden variable.
+     */
+    public function hide();
+
+    /**
+     * Returns whether this is a hidden variable.
+     *
+     * @return bool  True if this a hidden variable
+     */
+    public function isHidden();
+
+    /**
+     * Disables this variable.
+     */
+    public function disable();
+
+    /**
+     * Returns whether this variable is disabled.
+     *
+     * @return bool  True if this variable is disabled
+     */
+    public function isDisabled();
+
+    /**
+     * Return the short description of this variable.
+     *
+     * @return string  A short description
+     */
+    public function getHumanName();
+
+    /**
+     * Returns the internally used variable name.
+     *
+     * @return string  This variable's internal name
+     */
+    public function getVarName();
+
+    /**
+     * Returns the name of this variable's type.
+     *
+     * @return string  This variable's type name
+     */
+    public function getTypeName(): string;
+
+    /**
+     * Returns whether this variable has a long description.
+     *
+     * @return bool  True if this variable has a long description
+     */
+    public function hasDescription(): bool;
+
+    /**
+     * Returns this variable's long description.
+     *
+     * @return string  This variable's long description
+     */
+    public function getDescription();
+
+    /**
+     * Returns whether this is an array variable.
+     *
+     * @return bool  True if this an array variable
+     */
+    public function isArrayVal();
+
+    /**
+     * Returns whether this variable is to upload a file.
+     *
+     * @return bool  True if variable is to upload a file
+     */
+    public function isUpload();
+
+    /**
+     * Assigns a help text to this variable.
+     *
+     * @param string $help  The variable help text
+     */
+    public function setHelp($help);
+
+    /**
+     * Returns whether this variable has some help text assigned.
+     *
+     * @return bool  True if this variable has a help text
+     */
+    public function hasHelp();
+
+    /**
+     * Returns the help text of this variable.
+     *
+     * @return string  This variable's help text
+     */
+    public function getHelp();
+
+    /**
+     * Sets a variable option.
+     *
+     * @param string $option  The option name
+     * @param mixed $val      The option's value
+     */
+    public function setOption($option, $val);
+
+    /**
+     * Returns a variable option's value.
+     *
+     * @param string $option  The option name
+     *
+     * @return mixed  The option's value
+     */
+    public function getOption($option);
+
+    /**
+     * Processes the submitted value of this variable.
+     *
+     * @param Horde_Variables $vars  The submitted form variables
+     * @param mixed ...$args         Additional arguments (deprecated)
+     *
+     * @return mixed  Processed value of the variable
+     */
+    public function getInfo($vars, ...$args);
+
+    /**
+     * Returns whether this variable has been changed.
+     *
+     * @param Horde_Variables $vars  The submitted form variables
+     *
+     * @return ?bool  Null if trackchange not set, boolean otherwise
+     */
+    public function wasChanged($vars);
+
+    /**
+     * Validates this variable.
+     *
+     * @param Horde_Variables $vars  The submitted form variables
+     * @param mixed ...$args         Additional arguments (deprecated)
+     *
+     * @return bool  True if the variable validated
+     */
+    public function validate($vars, ...$args);
+
+    /**
+     * Returns the submitted or default value of this variable.
+     *
+     * @param Horde_Variables $vars  The submitted form variables
+     * @param int|null $index        Array element index if array variable
+     *
+     * @return mixed  The variable or element value
+     */
+    public function getValue($vars, $index = null);
+
+    /**
+     * Returns the possible values of this variable.
+     *
+     * @param mixed ...$params  Type-specific parameters
+     *
+     * @return array|null  The possible values or null
+     */
+    public function getValues(...$params);
+
+    /**
+     * Hook called on form submission.
+     *
+     * @param Horde_Variables $vars  Submitted form variables
+     */
+    public function onSubmit($vars);
+}

--- a/src/V3/VariableV3Interface.php
+++ b/src/V3/VariableV3Interface.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Copyright 2001-2026 Horde LLC (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (LGPL). If you
+ * did not receive this file, see http://www.horde.org/licenses/lgpl21.
+ *
+ * @author   Robert E. Coyle <robertecoyle@hotmail.com>
+ * @category Horde
+ * @license  http://www.horde.org/licenses/lgpl21 LGPL
+ * @package  Form
+ */
+
+namespace Horde\Form\V3;
+
+/**
+ * V3-native interface for Variable methods introduced in the V3 implementation.
+ *
+ * These methods are new to V3 and don't exist in lib/ (Horde_Form_Variable).
+ * They support the modernized PHP 8+ architecture and provide new functionality.
+ *
+ * @category Horde
+ * @package  Form
+ */
+interface VariableV3Interface
+{
+    /**
+     * Returns the validation error message.
+     *
+     * @return string  The validation error message
+     */
+    public function getMessage();
+
+    /**
+     * Gets internal property value by name.
+     *
+     * @param string $property  Property name (without underscore prefix)
+     *
+     * @return mixed  Property value, or null if not set
+     */
+    public function getProperty($property);
+
+    /**
+     * Sets internal property value by name.
+     *
+     * @param string $property  Property name (without underscore prefix)
+     * @param mixed $value      Value to set
+     */
+    public function setProperty($property, $value);
+
+    /**
+     * Initialize variable with type-specific parameters.
+     *
+     * @param mixed ...$params  Variable arguments specific to variable type
+     */
+    public function init(...$params);
+
+    /**
+     * Mark variable as invalid with error message.
+     *
+     * @param string $message  The error message
+     *
+     * @return bool  Always returns false
+     */
+    public function invalid(string $message): bool;
+
+    /**
+     * Return info about field type (metadata).
+     *
+     * @return array  Type metadata including name and parameters
+     */
+    public function about(): array;
+}

--- a/test/unit/FormTest.php
+++ b/test/unit/FormTest.php
@@ -33,6 +33,44 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(Horde_Form::class)]
 class FormTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Mock the global $injector for tests that use form tokens
+        if (!isset($GLOBALS['injector'])) {
+            $mockTokenSource = new class {
+                public function verify($token) {
+                    return true;
+                }
+            };
+
+            $GLOBALS['injector'] = new class($mockTokenSource) {
+                private $tokenSource;
+
+                public function __construct($tokenSource) {
+                    $this->tokenSource = $tokenSource;
+                }
+
+                public function getInstance($className) {
+                    if ($className === 'Horde_Token') {
+                        return $this->tokenSource;
+                    }
+                    return new \stdClass();
+                }
+            };
+        }
+
+        // Mock the global $session for tests that use form secrets
+        if (!isset($GLOBALS['session'])) {
+            $GLOBALS['session'] = new class {
+                public function get($app, $key) {
+                    return null;
+                }
+            };
+        }
+    }
+
     // ========================================================================
     // Constructor Tests
     // ========================================================================

--- a/test/unit/Type/TextTypeTest.php
+++ b/test/unit/Type/TextTypeTest.php
@@ -115,7 +115,7 @@ class TextTypeTest extends TestCase
     public function testIsValidReturnsFalseWhenExceedsMaxLength(): void
     {
         $type = new Horde_Form_Type_text();
-        $type->init(40, 10);  // Max 10 characters
+        $type->init('', 40, 10);  // regex='', size=40, maxlength=10
 
         $var = $this->createMockVariable(false);
         $vars = new Horde_Variables();
@@ -128,7 +128,7 @@ class TextTypeTest extends TestCase
     public function testIsValidReturnsTrueWhenWithinMaxLength(): void
     {
         $type = new Horde_Form_Type_text();
-        $type->init(40, 20);  // Max 20 characters
+        $type->init('', 40, 20);  // regex='', size=40, maxlength=20
 
         $var = $this->createMockVariable(false);
         $vars = new Horde_Variables();


### PR DESCRIPTION
**Most importantly:** 
- **fix: Restore deprecation warning for legacy getInfo() signature**

**Hope this also helps:**
- **docs: complete missing PHPDoc blocks in V3 codebase**
- **docs(api): add @api and @internal tags to V3 methods, add missing phpdoc**
- **feat(api): create distinct migration and V3-native interfaces**

@amulet1 You were right. This compat interface SHOULD warn when called in an unsupported way.

Let's draw the line more clearly between the parts of V3 which need to stay fixed for migration support and the parts which can currently develop freely.