### PR TITLE
Transition to V3 classes

### DIFF
--- a/lib/Horde/Form.php
+++ b/lib/Horde/Form.php
@@ -33,8 +33,12 @@ use Horde\Util\ArrayUtils;
  * @license   http://www.horde.org/licenses/lgpl21 LGPL
  * @package   Form
  */
+
+Horde_Form::$legacy = class_exists(Horde_Form_Type::class);
+
 class Horde_Form
 {
+    public static bool $legacy = false;
     protected static $init_params_cache = [];
 
     protected $_name = '';
@@ -164,67 +168,6 @@ class Horde_Form
         return $renderer;
     }
 
-    /**
-     * Initialize a Horde_Form_Type object from a type id (internal use only)
-     *
-     * This method is private as of 3.0.0-beta4 to encapsulate parameter normalization logic.
-     * External code should use Horde_Form_Type::create() instead for instantiating types.
-     *
-     * For legacy code not yet migrated to src/V3, use Horde_Form_Type::create($type, $params)
-     * which provides the same functionality with a stable public API.
-     *
-     * @param string $type Type identifier
-     * @param array $params Type initialization parameters
-     *
-     * @return Horde_Form_Type
-     * @throws Horde_Exception
-     *
-     * @since 3.0.0-beta4 Changed to private visibility
-     */
-    private static function getType($type, $params = [])
-    {
-        if (strpos($type, ':') !== false) {
-            [$app, $type] = explode(':', $type);
-            $type_class = $app . '_Form_Type_' . $type;
-        } else {
-            $type_class = 'Horde_Form_Type_' . $type;
-        }
-        if (!class_exists($type_class)) {
-            throw new Horde_Exception(sprintf('Nonexistant class "%s" for field type "%s"', $type_class, $type));
-        }
-        $type_ob = new $type_class();
-        if (!$params) {
-            $params = [];
-        }
-
-        // retrieve list of parameters
-        $keys = self::$init_params_cache[$type_class] ?? null;
-        if (is_null($keys)) {
-            $keys = array_keys($type_ob->about()['params'] ?? []);
-            self::$init_params_cache[$type_class] = $keys;
-        }
-
-        // convert named parameters to positional
-        $i = 0;
-        $ni = 0;
-        foreach ($keys as $key) {
-            if (array_key_exists($key, $params)) {
-                // make sure prior index(es) exist
-                while ($ni < $i) {
-                    if (!array_key_exists($ni, $params)) {
-                        $params[$ni] = null;
-                    }
-                    ++$ni;
-                }
-                $params[$ni++] = $params[$key];
-                unset($params[$key]);
-            }
-            ++$i;
-        }
-
-        $type_ob->init(...$params);
-        return $type_ob;
-    }
 
     /**
      * Create a new Horde_Form_Variable instance without attaching it to the form.
@@ -257,10 +200,73 @@ class Horde_Form
         $readonly = false,
         $description = null,
     ) {
+        $arr = explode(':', $type, 2);
+        if (count($arr) == 2) {
+            $app = $arr[0];
+            $name = $arr[1];
+        } else {
+            $app = 'Horde';
+            $name = $arr[0];
+        }
+
+        $class = $app . '\\Form\\V3\\' . ucfirst($name) . 'Variable';
+        $modern = class_exists($class);
+        if ($modern) {
+            $var = new $class(
+                $humanName,
+                $varName,
+                $required,
+                $readonly,
+                $description
+            );
+        } elseif (self::$legacy) {
+            $class = $app . '_Form_Type_' . $name;
+            if (!class_exists($class)) {
+                throw new Horde_Exception(sprintf('Nonexistent class "%s" for field type "%s"', $class, $name));
+            }
+            $var = new $class();
+        } else {
+            throw new Horde_Exception(sprintf('Nonexistent class "%s" for field type "%s"', $class, $name));
+        }
+
+        // retrieve list of parameters
+        $keys = self::$init_params_cache[$class] ?? null;
+        if (is_null($keys)) {
+            $keys = array_keys($var->about()['params'] ?? []);
+            self::$init_params_cache[$class] = $keys;
+        }
+
+        if (!$params) {
+            $params = [];
+        }
+
+        // convert named parameters to positional
+        $i = 0;
+        $ni = 0;
+        foreach ($keys as $key) {
+            if (array_key_exists($key, $params)) {
+                // make sure prior index(es) exist
+                while ($ni < $i) {
+                    if (!array_key_exists($ni, $params)) {
+                        $params[$ni] = null;
+                    }
+                    ++$ni;
+                }
+                $params[$ni++] = $params[$key];
+                unset($params[$key]);
+            }
+            ++$i;
+        }
+
+        $var->init(...$params);
+        if ($modern) {
+            return $var;
+        }
+
         return new Horde_Form_Variable(
             $humanName,
             $varName,
-            self::getType($type, $params),
+            $var,
             $required,
             $readonly,
             $description
@@ -463,8 +469,8 @@ class Horde_Form
     {
         foreach (array_keys($this->_variables) as $section) {
             foreach (array_keys($this->_variables[$section]) as $i) {
-                if ((is_a($var, 'Horde_Form_Variable') && $this->_variables[$section][$i] === $var)
-                    || ($this->_variables[$section][$i]->getVarName() == $var)) {
+                if ((is_object($var) && $this->_variables[$section][$i] === $var)
+                    || ($this->_variables[$section][$i]->getVarName() === $var)) {
                     // Slice out the variable to be removed.
                     $this->_variables[$section] = array_merge(
                         array_slice($this->_variables[$section], 0, $i),
@@ -852,31 +858,19 @@ class Horde_Form
 
     public function getError($var)
     {
-        if (is_a($var, 'Horde_Form_Variable')) {
-            $name = $var->getVarName();
-        } else {
-            $name = $var;
-        }
+        $name = is_string($var) ? $var : $var->getVarName();
         return $this->_errors[$name] ?? null;
     }
 
     public function setError($var, $message)
     {
-        if (is_a($var, 'Horde_Form_Variable')) {
-            $name = $var->getVarName();
-        } else {
-            $name = $var;
-        }
+        $name = is_string($var) ? $var : $var->getVarName();
         $this->_errors[$name] = $message;
     }
 
     public function clearError($var)
     {
-        if (is_a($var, 'Horde_Form_Variable')) {
-            $name = $var->getVarName();
-        } else {
-            $name = $var;
-        }
+        $name = is_string($var) ? $var : $var->getVarName();
         unset($this->_errors[$name]);
     }
 

--- a/src/V3/BaseVariable.php
+++ b/src/V3/BaseVariable.php
@@ -17,6 +17,7 @@ namespace Horde\Form\V3;
 use Horde_Variables;
 use Horde;
 use Horde_Form_Translation;
+use Horde\Form\Form;
 
 /**
  * This class represents a single form variable that may be rendered as one or
@@ -33,7 +34,7 @@ class BaseVariable implements Variable
     /**
      * The form instance this variable is assigned to.
      */
-    public Horde\Form\Form $form;
+    public Form|\Horde_Form $form;
 
     /**
      * A short description of this variable's purpose.
@@ -94,7 +95,7 @@ class BaseVariable implements Variable
     /**
      * A {@link Action} instance.
      */
-    public ?Action $_action = null;
+    public Action|\Horde_Form_Action|null $_action = null;
 
     /**
      * Whether this variable is disabled.


### PR DESCRIPTION
This allows a seamless migration to V3 classes, while still supporting legacy `{app}_Form_Type_{type}` classes that do not yet have the correct  V3 classes.

Note, the 3828e85 commit (included here because if affects V3 class too) provides a global fix to the behavior change in `getInfo()` for 'file' type. The horde/turba@5abeb2d fix is no longer needed as a result (and it was fixing it only in Turba, anyway).

Experimental, cherry-picked from my fork.
