### PR TITLE
Add __call magic method to delegate undefined methods to $type

### DIFF
--- a/lib/Horde/Form/Variable.php
+++ b/lib/Horde/Form/Variable.php
@@ -140,6 +140,15 @@ class Horde_Form_Variable
     }
 
     /**
+     * Forward calls to undefined methods to $this->type
+     *
+     */
+    public function __call(string $method, array $args)
+    {
+        return $this->type->$method(...$args);
+    }
+
+    /**
      * Variable constructor.
      *
      * @param string $humanName      A short description of the variable's


### PR DESCRIPTION
Forwards any undefined method calls to $this->type to maintain forward compatibility with V3 changes.