### PR TITLE
fix(form): stop passing deprecated $message to V3 variables in validate()

### DIFF
--- a/lib/Horde/Form.php
+++ b/lib/Horde/Form.php
@@ -824,7 +824,10 @@ class Horde_Form
 
         foreach ($this->getVariables() as $var) {
             $this->_autofilled = $var->_autofilled && $this->_autofilled;
-            if (!$var->validate($vars, $message)) {
+            $valid = $var instanceof Horde_Form_Variable
+                ? $var->validate($vars, $message)
+                : $var->validate($vars);
+            if (!$valid) {
                 $this->_errors[$var->getVarName()] = $var->getMessage();
             }
         }
@@ -834,7 +837,10 @@ class Horde_Form
         }
 
         foreach ($this->_hiddenVariables as $var) {
-            if (!$var->validate($vars, $message)) {
+            $valid = $var instanceof Horde_Form_Variable
+                ? $var->validate($vars, $message)
+                : $var->validate($vars);
+            if (!$valid) {
                 $this->_errors[$var->getVarName()] = $var->getMessage();
             }
         }


### PR DESCRIPTION
## Summary
- Fixes log spam when legacy `Horde_Form` validates forms that use V3 variables created by `Horde_Form::createVariable()`. 
- `Horde_Form::validate()` no longer passes the deprecated second `$message` argument to V3 `BaseVariable` instances; it is still passed for legacy `Horde_Form_Variable` wrappers (e.g. app-specific types without a V3 class).
- Aligns legacy form validation with `Horde\Form\V3\BaseForm::validate()`, which already calls `$var->validate($vars)` with a single argument.
## Problem
`Horde_Form::createVariable()` now returns V3 variables (e.g. `Horde\Form\V3\TextVariable`) when a modern class exists. Legacy `Horde_Form::validate()` still called:
