### PR TITLE
Fix/image variable

### DIFF
--- a/lib/Horde/Form/Type.php
+++ b/lib/Horde/Form/Type.php
@@ -1570,7 +1570,7 @@ class Horde_Form_Type_image extends Horde_Form_Type
     public function getRandomId()
     {
         if (!isset($this->_random)) {
-            $this->_random = uniqid(mt_rand());
+            $this->_random = uniqid((string)mt_rand());
         }
         return $this->_random;
     }

--- a/src/V3/ImageVariable.php
+++ b/src/V3/ImageVariable.php
@@ -458,7 +458,7 @@ class ImageVariable extends BaseVariable implements FileUploadAware
     public function getRandomId()
     {
         if (!isset($this->_random)) {
-            $this->_random = uniqid(mt_rand());
+            $this->_random = uniqid((string)mt_rand());
         }
 
         return $this->_random;


### PR DESCRIPTION
# Fix PHP 8 `uniqid()` type error in image form fields

## Summary

- Cast `mt_rand()` to string in `getRandomId()` so `uniqid()` receives a valid prefix on PHP 8+.
- Apply the fix in both the V3 `ImageVariable` class and the legacy `Horde_Form_Type_image` implementation.

## Problem

On PHP 8.0+, `uniqid()` requires its first argument (`$prefix`) to be a string. Both image field implementations call:

```php
$this->_random = uniqid(mt_rand());
```

`mt_rand()` returns an `int`, which triggers:

```
TypeError: uniqid(): Argument #1 ($prefix) must be of type string, int given
```

This aborts form rendering whenever an existing image is loaded into the field — for example when Turba displays or edits a contact with a photo. The contact view fails entirely (left pane not rendered) because the exception is thrown while building the image input in `Horde_Form\V3\ImageVariable->getImage()`.

Observed stack trace (Turba):

```
Turba_View_Contact->html()
  → Turba_Form_EditContact->renderActive()
    → Horde_Form_Renderer->renderFormActive()
      → Turba_Ui_VarRenderer_Html->_renderVarInput_image()
        → Horde\Form\V3\ImageVariable->getImage()
          → Horde\Form\V3\ImageVariable->getRandomId()
            → uniqid()  // TypeError
```

## Solution

Cast the random prefix to string, preserving the original intent of adding entropy to the session key:

```php
$this->_random = uniqid((string)mt_rand());
```

Changed in:

- `src/V3/ImageVariable.php` — `getRandomId()`
- `lib/Horde/Form/Type.php` — `Horde_Form_Type_image::getRandomId()`

## Related work

The same `uniqid(mt_rand())` pattern appears elsewhere in the framework (e.g. `Horde_Config`, `Horde_Util`, `Horde_Core_Ui_VarRenderer_Html`). Those call sites may need the same cast if they are hit on PHP 8+, but they are outside the scope of this image-field fix.

## Test plan

- [ ] Open a Turba contact **with** a photo; confirm the contact view and left pane render without error.
- [ ] Open a Turba contact **without** a photo; confirm editing still works.
- [ ] Upload or replace a contact photo via the edit form; confirm the new image is saved and displayed.
- [ ] Verify no `TypeError` from `uniqid()` in Horde logs when loading contacts with photos.
- [ ] Run on PHP 8.4 (or the project's minimum supported PHP 8.x version) to confirm the type error is gone.
