### PR TITLE
fix(form): recognize Horde\{App}\...\FooVariable in BaseVariable::getTypeName()

### DIFF
--- a/src/V3/BaseVariable.php
+++ b/src/V3/BaseVariable.php
@@ -341,17 +341,33 @@ class BaseVariable implements Variable
      * @return string  This variable's {@link Horde_Form_Type} name.
      *
      * Override with a simple return 'literal' string in your own types.
-      *
-      * @api
+     *
+     * The default derives the type name from the class namespace so app
+     * variables map back to their legacy `{app}_form_type_{name}` handles
+     * (used e.g. by `Horde_Core_Ui_VarRenderer::render()` when dispatching
+     * to `_renderVarInput_{typename}` methods). Three shapes are covered:
+     *
+     * - `Horde\Form\V3\FooVariable`         → `foo`
+     *   Vendor-owned horde/form variables use the bare name.
+     * - `Horde\{App}\...\FooVariable`       → `{app}_form_type_foo`
+     *   Vendor-namespaced app variables (PSR-4 `Horde\Ingo\Form\V3\…`).
+     * - `{App}\...\FooVariable`             → `{app}_form_type_foo`
+     *   Legacy pre-PSR-4 app variables (`Ingo\Form\V3\…`).
+     *
+     * @api
      */
     public function getTypeName(): string
     {
         $parts = explode('\\', $this::class);
-        $app =  strtolower($parts[0]);
-        $name =  strtolower(substr($parts[count($parts) - 1], 0, -8));
-        if ($app !== 'horde') {
-            // legacy
-            $name = $app . '_form_type_' . $name;
+        $name = strtolower(substr($parts[count($parts) - 1], 0, -8));
+        $vendor = strtolower($parts[0]);
+        if ($vendor !== 'horde') {
+            // Legacy pre-PSR-4 app layout: `{App}\...\FooVariable`.
+            return $vendor . '_form_type_' . $name;
+        }
+        if (count($parts) >= 3 && strtolower($parts[1]) !== 'form') {
+            // Vendor-namespaced app layout: `Horde\{App}\...\FooVariable`.
+            return strtolower($parts[1]) . '_form_type_' . $name;
         }
         return $name;
     }

--- a/test/bootstrap.php
+++ b/test/bootstrap.php
@@ -7,6 +7,10 @@
 // Load Composer autoloader
 require_once __DIR__ . '/../vendor/autoload.php';
 
+// Fixture classes declared in namespaces that PSR-4 autoloading in test/
+// cannot express (see BaseVariable::getTypeName() coverage).
+require_once __DIR__ . '/v3/fixtures/GetTypeNameFixtures.php';
+
 // Setup minimal global mocks for Horde dependencies
 // These are needed by Horde_Form when form tokens are enabled
 

--- a/test/v3/V3BaseVariableTest.php
+++ b/test/v3/V3BaseVariableTest.php
@@ -175,6 +175,24 @@ class V3BaseVariableTest extends TestCase
         $this->assertEquals('text', $var->getTypeName());
     }
 
+    public function testGetTypeNameForVendorNamespacedAppVariable(): void
+    {
+        // `Horde\Fakeapp\Form\V3\FoldersVariable` — modern PSR-4 app layout.
+        // See test/v3/fixtures/GetTypeNameFixtures.php.
+        $var = new \Horde\Fakeapp\Form\V3\FoldersVariable('Folder', 'folder', false);
+
+        $this->assertEquals('fakeapp_form_type_folders', $var->getTypeName());
+    }
+
+    public function testGetTypeNameForLegacyAppVariable(): void
+    {
+        // `Fakeapp\Form\V3\FoldersVariable` — pre-PSR-4 legacy app layout.
+        // See test/v3/fixtures/GetTypeNameFixtures.php.
+        $var = new \Fakeapp\Form\V3\FoldersVariable('Folder', 'folder', false);
+
+        $this->assertEquals('fakeapp_form_type_folders', $var->getTypeName());
+    }
+
     public function testIsRequired(): void
     {
         $requiredVar = new TextVariable('Name', 'name', true);

--- a/test/v3/fixtures/GetTypeNameFixtures.php
+++ b/test/v3/fixtures/GetTypeNameFixtures.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Fixtures for BaseVariable::getTypeName() tests.
+ *
+ * Copyright 2026 Horde LLC (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (LGPL-2.1).
+ *
+ * Declared in dedicated namespace blocks so getTypeName() can be exercised
+ * against class-name shapes that PSR-4 autoloading in test/ (which is mapped
+ * to Horde\Form\Test\) cannot express directly.
+ *
+ * @category   Horde
+ * @package    Form
+ * @subpackage UnitTests
+ * @license    http://www.horde.org/licenses/lgpl21 LGPL-2.1
+ */
+
+namespace Horde\Fakeapp\Form\V3 {
+
+    use Horde\Form\V3\BaseVariable;
+
+    /**
+     * Vendor-namespaced app variable shape: `Horde\{App}\...\FooVariable`.
+     *
+     * Expected getTypeName(): `fakeapp_form_type_folders`.
+     */
+    class FoldersVariable extends BaseVariable
+    {
+    }
+}
+
+namespace Fakeapp\Form\V3 {
+
+    use Horde\Form\V3\BaseVariable;
+
+    /**
+     * Legacy pre-PSR-4 app variable shape: `{App}\...\FooVariable`.
+     *
+     * Expected getTypeName(): `fakeapp_form_type_folders`.
+     */
+    class FoldersVariable extends BaseVariable
+    {
+    }
+}


### PR DESCRIPTION
## Summary

`BaseVariable::getTypeName()` derives a variable's legacy type handle from its class namespace. `Horde_Core_Ui_VarRenderer::render()` uses that handle to dispatch to `_renderVarInput_{typename}` methods on app-provided renderers.

Before this change the derivation covered two shapes:

- `Horde\Form\V3\TextVariable` → `text` (vendor)
- `Ingo\Form\V3\FoldersVariable` → `ingo_form_type_folders` (legacy pre-PSR-4 app)

A vendor-namespaced app variable — `Horde\Ingo\Form\V3\FoldersVariable`, the shape that horde/form 3.1's FQCN support encourages apps to migrate to — collapsed to just `folders`, so the legacy renderer method `_renderVarInput_ingo_form_type_folders` was never dispatched and users saw "Unknown variable type" warnings on the affected screens.

`getTypeName()` now recognizes all three shapes:

| Class | Returns |
|---|---|
| `Horde\Form\V3\TextVariable` | `text` |
| `Ingo\Form\V3\FoldersVariable` | `ingo_form_type_folders` |
| `Horde\Ingo\Form\V3\FoldersVariable` | `ingo_form_type_folders` |

Detection is `parts[0] === 'Horde' && parts[1] !== 'Form'` → vendor-namespaced app, prefix with `strtolower(parts[1]) . '_form_type_'`.

Existing `testGetTypeName()` covers the vendor path unchanged. Two new cases in `V3BaseVariableTest` exercise the vendor-namespaced and legacy app paths using stub Variable classes declared in `test/v3/fixtures/GetTypeNameFixtures.php` (PSR-4 in `test/` is mapped to `Horde\Form\Test\`, so the fixture file uses bracketed namespace blocks and is loaded from the existing bootstrap).

Surfaced by horde/ingo#34, which moves ingo's custom Variable classes from `Ingo\Form\V3` to `Horde\Ingo\Form\V3`. Ingo has a local `getTypeName()` override in place to unblock that PR; once this ships those overrides become optional.